### PR TITLE
Minor cleanups

### DIFF
--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -223,6 +223,18 @@ class IDataFrame(IColumn):
             )
         return self._format_transform_result(raw_res, format, dtype, len(self))
 
+    def get_column(self, column):
+        """Return the named column"""
+        raise self._not_supported("get_column")
+
+    def get_columns(self, columns):
+        """Return a new dataframe referencing the columns[s1],..,column[sm]"""
+        raise self._not_supported("get_columns")
+
+    def slice_columns(self, start, stop):
+        """Return a new dataframe with the slice rows[start:stop]"""
+        raise self._not_supported("slice_columns")
+
     @trace
     def to_python(self):
         tup_type = self._dtype.py_type

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -337,7 +337,6 @@ class TestDataFrame(unittest.TestCase):
             list(df.nsmallest(n=2, columns=["c", "a"], keep="first")),
             [(3, 3.0, 1), (1, 1.0, 4)],
         )
-        self.assertEqual(list(df.reverse()), [(3, 3.0, 1), (2, None, 4), (1, 1.0, 4)])
 
     def base_test_operators(self):
         # without None

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -227,10 +227,6 @@ class TestNumericalColumn(unittest.TestCase):
             ),
             [1, 2],
         )
-        self.assertEqual(
-            list(ta.Column([None, 1, 5, 2], device=self.device).reverse()),
-            [2, 5, 1, None],
-        )
 
     def base_test_operators(self):
         # without None

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -1268,7 +1268,7 @@ class DataFrameCpu(IDataFrame, ColumnFromVelox):
     def fillna(self, fill_value: Union[dt.ScalarTypes, Dict, Literal[None]]):
         if fill_value is None:
             return self
-        if isinstance(fill_value, IColumn.scalar_types):
+        if isinstance(fill_value, IColumn._scalar_types):
             return self._fromdata(
                 {
                     self.dtype.fields[i]

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -294,7 +294,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     def __radd__(self, other: Union[int, float]) -> INumericalColumn:
         """Vectorized b + a."""
         return self._checked_arithmetic_op_call(
-            other, "radd", IColumn.swap(operator.add)
+            other, "radd", IColumn._swap(operator.add)
         )
 
     @trace
@@ -308,7 +308,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     def __rsub__(self, other: Union[int, float]) -> INumericalColumn:
         """Vectorized b - a."""
         return self._checked_arithmetic_op_call(
-            other, "rsub", IColumn.swap(operator.sub)
+            other, "rsub", IColumn._swap(operator.sub)
         )
 
     @trace
@@ -322,7 +322,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     def __rmul__(self, other: Union[int, float]) -> INumericalColumn:
         """Vectorized b * a."""
         return self._checked_arithmetic_op_call(
-            other, "rmul", IColumn.swap(operator.mul)
+            other, "rmul", IColumn._swap(operator.mul)
         )
 
     @trace
@@ -435,7 +435,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     def __rmod__(self, other: Union[int, float]) -> INumericalColumn:
         """Vectorized b % a."""
         return self._checked_arithmetic_op_call(
-            other, "rmod", IColumn.swap(operator.mod)
+            other, "rmod", IColumn._swap(operator.mod)
         )
 
     @trace
@@ -541,7 +541,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     def __rand__(self, other: Union[int]) -> INumericalColumn:
         """Vectorized b & a."""
         return self._checked_arithmetic_op_call(
-            other, "bitwise_rand", IColumn.swap(operator.__and__)
+            other, "bitwise_rand", IColumn._swap(operator.__and__)
         )
 
     @trace
@@ -555,7 +555,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     def __ror__(self, other: Union[int]) -> INumericalColumn:
         """Vectorized b | a."""
         return self._checked_arithmetic_op_call(
-            other, "bitwise_ror", IColumn.swap(operator.__or__)
+            other, "bitwise_ror", IColumn._swap(operator.__or__)
         )
 
     @trace
@@ -569,7 +569,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     def __rxor__(self, other: Union[int]) -> INumericalColumn:
         """Vectorized b | a."""
         return self._checked_arithmetic_op_call(
-            other, "bitwise_rxor", IColumn.swap(operator.__xor__)
+            other, "bitwise_rxor", IColumn._swap(operator.__xor__)
         )
 
     @trace
@@ -656,7 +656,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     @expression
     def fillna(self, fill_value: Union[dt.ScalarTypes, Dict]):
         """Fill NA/NaN values using the specified method."""
-        if not isinstance(fill_value, IColumn.scalar_types):
+        if not isinstance(fill_value, IColumn._scalar_types):
             raise TypeError(f"fillna with {type(fill_value)} is not supported")
         if not self.isnullable:
             return self


### PR DESCRIPTION
Summary:
1. Rearrange private methods to the end of `IColumn`
2. Move `get_column/slice_column` methos to `IDataFrame`
3. Rename `astype` to `cast`
4. Remove `IColumn.reverse` (not streaming-friendly, trivially done via `col[::-1]`, also not even existing in Pandas)

Reviewed By: dracifer

Differential Revision: D32009660

