### PR TITLE
add __contains__(), get_default() to DataFrame

### DIFF
--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -158,6 +158,12 @@ class IDataFrame(IColumn):
         """
         raise self._not_supported("_set_field_data")
 
+    def __contains__(self, key: str) -> bool:
+        for f in self.dtype.fields:
+            if key == f.name:
+                return True
+        return False
+
     @trace
     def __setitem__(self, name: str, value: Any) -> None:
         if isinstance(value, IColumn):

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -728,6 +728,13 @@ class TestDataFrame(unittest.TestCase):
         self.assertEqual(list(r), [1000, None, None])
         self.assertEqual(r.dtype, dt.int64)
 
+    def base_test_in(self):
+        df = ta.DataFrame(
+            {"A": ["a", "b", "a", "b"], "B": [1, 2, 3, 4]}, device=self.device
+        )
+        self.assertTrue("A" in df)
+        self.assertFalse("X" in df)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torcharrow/test/test_dataframe_cpu.py
+++ b/torcharrow/test/test_dataframe_cpu.py
@@ -84,6 +84,9 @@ class TestDataFrameCpu(TestDataFrame):
     def test_infer_func_output_dtype(self):
         return self.base_test_infer_func_output_dtype()
 
+    def test_in(self):
+        return self.base_test_in()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -2042,6 +2042,15 @@ class GroupedDataFrame:
                 cols[i]._append(t)
         return [col._finalize() for col in cols]
 
+    def __contains__(self, key: str):
+        for f in self._item_fields:
+            if f.name == key:
+                return True
+        for f in self._key_fields:
+            if f.name == key:
+                return True
+        return False
+
     def __getitem__(self, arg):
         """
         Return the named grouped column


### PR DESCRIPTION
Summary:
as title. it will make life easier

get() is registered by icolumn for index fetching... we can generalize it as well if preferred

Differential Revision: D32032534

