### PR TITLE
Some API cleanup

### DIFF
--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -774,7 +774,7 @@ _agg_ops = {
     "mean": lambda c: c.mean(),
     "median": lambda c: c.median(),
     "mode": lambda c: c.mode(),
-    "count": lambda c: c.count(),
+    "count": lambda c: c._count(),
 }
 
 

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -114,9 +114,25 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
 
     @property  # type: ignore
     @traceproperty
-    def isnullable(self):
-        """A boolean indicating whether column/frame can have nulls"""
+    def is_nullable(self):
+        """
+        EXPERIMENTAL API
+
+        A boolean indicating whether column/frame can have nulls
+        """
         return self.dtype.nullable
+
+    @property  # type: ignore
+    @traceproperty
+    def length(self):
+        """Return number of rows including null values"""
+        return len(self)
+
+    @property  # type: ignore
+    @traceproperty
+    def null_count(self):
+        """Return number of null values"""
+        raise self._not_supported("null_count")
 
     # public append/copy/cast------------------------------------------------
 
@@ -142,7 +158,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         """
         # TODO use _column_copy, but for now this works...
         res = Scope._EmptyColumn(self.dtype)
-        for (m, d) in self.items():
+        for (m, d) in self._items():
             if m:
                 res._append_null()
             else:
@@ -186,29 +202,10 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
 
     @trace
     @expression
-    def count(self):
-        """Return number of non-NA/null observations pgf the column/frame"""
-        return len(self) - self.null_count()
-
-    @trace
-    @expression
-    @abc.abstractmethod
-    def null_count(self):
-        """Return number of null values"""
-        raise self._not_supported("null_count")
-
-    @trace
-    @expression
     @abc.abstractmethod
     def __len__(self):
         """Return number of rows including null values"""
         raise self._not_supported("__len__")
-
-    @trace
-    @expression
-    def length(self):
-        """Return number of rows including null values"""
-        return len(self)
 
     # printing ----------------------------------------------------------------
 
@@ -222,31 +219,18 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             tablefmt="plain",
             showindex=True,
         )
-        typ = f"dtype: {self._dtype}, length: {len(self)}, null_count: {self.null_count()}"
+        typ = f"dtype: {self._dtype}, length: {len(self)}, null_count: {self.null_count}"
         return tab + dt.NL + typ
 
     # selectors/getters -------------------------------------------------------
 
-    @abc.abstractmethod
-    def getmask(self, i):
-        """Return mask at index i"""
-        raise self._not_supported("getmask")
+    def is_valid_at(self, index):
+        """
+        EXPERIMENTAL API
 
-    @abc.abstractmethod
-    def getdata(self, i):
-        """Return data at index i"""
-        raise self._not_supported("getdata")
-
-    def valid(self, index):
-        """Return whether data at index i is valid, i.e., non-masked"""
-        return not self.getmask(index)
-
-    def get(self, index, fill_value=None):
-        """Return data[index] or fill_value if data[i] not valid"""
-        if self.getmask(index):
-            return fill_value
-        else:
-            return self.getdata(index)
+        Return whether data at index i is valid, i.e., non-null
+        """
+        return not self._getmask(index)
 
     @trace
     @expression
@@ -267,7 +251,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         """
 
         if isinstance(arg, int):
-            return self.get(arg)
+            return self._get(arg)
         elif isinstance(arg, str):
             return self.get_column(arg)
         elif isinstance(arg, slice):
@@ -278,7 +262,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                 else:
                     args.append(i)
             if all(a is None or isinstance(a, int) for a in args):
-                return self.slice(*args)
+                return self._slice(*args)
             elif all(a is None or isinstance(a, str) for a in args):
                 if arg.step is not None:
                     raise TypeError(f"column slice can't have step argument {arg.step}")
@@ -293,7 +277,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             if all(isinstance(a, bool) for a in arg):
                 return self.filter(arg)
             if all(isinstance(a, int) for a in arg):
-                return self.gets(arg)
+                return self._gets(arg)
             if all(isinstance(a, str) for a in arg):
                 return self.get_columns(arg)
             else:
@@ -302,28 +286,6 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             return self.filter(arg)
         else:
             raise self._not_supported("__getitem__")
-
-    def gets(self, indices):
-        """Return a new column with the rows[indices[0]],..,rows[indices[-1]]"""
-        res = Scope._EmptyColumn(self.dtype)
-        for i in indices:
-            (m, d) = (self.getmask(i), self.getdata(i))
-            if m:
-                res._append_null()
-            else:
-                res._append_value(d)
-        return res._finalize()
-
-    def slice(self, start, stop, step):
-        """Return a new column with the slice rows[start:stop:step]"""
-        res = Scope._EmptyColumn(self.dtype)
-        for i in list(range(len(self)))[start:stop:step]:
-            m = self.getmask(i)
-            if m:
-                res._append_null()
-            else:
-                res._append_value(self.getdata(i))
-        return res._finalize()
 
     @trace
     @expression
@@ -360,6 +322,8 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     @expression
     def tail(self, n=5):
         """
+        EXPERIMENTAL API
+
         Return the last `n` rows.
 
         Parameters
@@ -391,21 +355,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     def __iter__(self):
         """Return the iterator object itself."""
         for i in range(len(self)):
-            yield self.get(i)
-
-    def items(self):
-        """Iterator returning mask,data pairs for all items of a column"""
-        for i in range(len(self)):
-            yield (self.getmask(i), self.getdata(i))
-
-    def data(self, fill_value=None):
-        """Iterator returning non-null or fill_value data of a column"""
-        for m, i in self.items():
-            if m:
-                if fill_value is not None:
-                    yield fill_value
-            else:
-                yield i
+            yield self._get(i)
 
     # functools map/filter/reduce ---------------------------------------------
 
@@ -570,7 +520,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         # in a Python list and then passing the list to the constructor
         res = []
         if isinstance(arg, defaultdict):
-            for masked, i in self.items():
+            for masked, i in self._items():
                 if not masked:
                     res.append(arg[i])
                 elif na_action is None:
@@ -578,7 +528,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                 else:
                     res.append(None)
         elif isinstance(arg, dict):
-            for masked, i in self.items():
+            for masked, i in self._items():
                 if not masked:
                     if i in arg:
                         res.append(arg[i])
@@ -593,7 +543,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             if dtype is None:
                 (dtype, _) = dt.infer_dype_from_callable_hint(arg)
 
-            for masked, i in self.items():
+            for masked, i in self._items():
                 if not masked:
                     res.append(arg(i))
                 elif na_action is None:
@@ -660,7 +610,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
 
         dtype = dtype or self.dtype
         res = Scope._EmptyColumn(dtype)
-        for masked, i in self.items():
+        for masked, i in self._items():
             if not masked:
                 res._extend(func(i))
             elif na_action is None:
@@ -780,7 +730,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                 "then and else branches must have compatible types, got {then_.dtype} and {else_.dtype}, respectively"
             )
         res = Scope._EmptyColumn(lub)
-        for (m, b), t, e in zip(self.items(), then_, else_):
+        for (m, b), t, e in zip(self._items(), then_, else_):
             if m:
                 res._append_null()
             elif b:
@@ -830,10 +780,10 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             raise TypeError("sorting a non-structured column can't have 'by' parameter")
         res = Scope._EmptyColumn(self.dtype)
         if na_position == "first":
-            res._extend([None] * self.null_count())
+            res._extend([None] * self.null_count)
         res._extend(sorted((i for i in self if i is not None), reverse=not ascending))
         if na_position == "last":
-            res._extend([None] * self.null_count())
+            res._extend([None] * self.null_count)
         return res._finalize()
 
     @trace
@@ -1084,7 +1034,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         """
         # note mask is True
         res = Scope._EmptyColumn(dt.boolean)
-        for m, i in self.items():
+        for m, i in self._items():
             if m:
                 res._append_value(False)
             else:
@@ -1148,7 +1098,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             raise TypeError(f"fillna with {type(fill_value)} is not supported")
         if isinstance(fill_value, IColumn._scalar_types):
             res = Scope._EmptyColumn(self.dtype.constructor(nullable=False))
-            for m, i in self.items():
+            for m, i in self._items():
                 if not m:
                     res._append_value(i)
                 else:
@@ -1186,7 +1136,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         """
         if dt.is_primitive(self.dtype):
             res = Scope._EmptyColumn(self.dtype.constructor(nullable=False))
-            for m, i in self.items():
+            for m, i in self._items():
                 if not m:
                     res._append_value(i)
             return res._finalize()
@@ -1231,7 +1181,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         1
         """
 
-        return min(self.data(fill_value))
+        return min(self._data_iter(fill_value))
 
     @trace
     @expression
@@ -1251,19 +1201,19 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         >>> s = ta.Column([1,2,None,4])
         >>> s.max(fill_value=999)
         """
-        return max(self.data(fill_value))
+        return max(self._data_iter(fill_value))
 
     @trace
     @expression
     def all(self):
         """Return whether all non-null elements are True"""
-        return all(self.data())
+        return all(self._data_iter())
 
     @trace
     @expression
     def any(self, skipna=True):
         """Return whether any non-null element is True in Column"""
-        return any(self.data())
+        return any(self._data_iter())
 
     @trace
     @expression
@@ -1285,14 +1235,14 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         1006
         """
         self._check(dt.is_numerical, "sum")
-        return sum(self.data())
+        return sum(self._data_iter())
 
     @trace
     @expression
     def prod(self):
         """Return produce of the non-null values in the data"""
         self._check(dt.is_numerical, "prod")
-        return reduce(operator.mul, self.data(), 1)
+        return reduce(operator.mul, self._data_iter(), 1)
 
     @trace
     @expression
@@ -1340,7 +1290,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         >>> s.mean(fill_value=999)
         251.5
         """
-        m = statistics.mean((float(i) for i in list(self.data())))
+        m = statistics.mean((float(i) for i in list(self._data_iter())))
         return m
 
     @trace
@@ -1348,21 +1298,21 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     def median(self):
         """Return the median of the values in the data."""
         self._check(dt.is_numerical, "median")
-        return statistics.median((float(i) for i in list(self.data())))
+        return statistics.median((float(i) for i in list(self._data_iter())))
 
     @trace
     @expression
     def mode(self):
         """Return the mode(s) of the data."""
         self._check(dt.is_numerical, "mode")
-        return statistics.mode(self.data())
+        return statistics.mode(self._data_iter())
 
     @trace
     @expression
     def std(self):
         """Return the stddev(s) of the data."""
         self._check(dt.is_numerical, "std")
-        return statistics.stdev((float(i) for i in list(self.data())))
+        return statistics.stdev((float(i) for i in list(self._data_iter())))
 
     @trace
     @expression
@@ -1441,7 +1391,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                     [dt.Field("statistic", dt.string), dt.Field("value", dt.float64)]
                 )
             )
-            res._append(("count", self.count()))
+            res._append(("count", self._count()))
             res._append(("mean", self.mean()))
             res._append(("std", self.std()))
             res._append(("min", self.min()))
@@ -1521,7 +1471,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             raise ValueError("can't determine column type")
         return res[0].concat(res[1:])
 
-    # private helpers ---------------------------------------------------------
+    # private helpers
 
     def _not_supported(self, name):
         raise TypeError(f"{name} for type {type(self).__name__} is not supported")
@@ -1572,7 +1522,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         others = None
         other_dtype = None
         if isinstance(other, IColumn):
-            others = other.items()
+            others = other._items()
             other_dtype = other.dtype
         else:
             others = itertools.repeat((False, other))
@@ -1586,7 +1536,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         res = []
         if div != "":
             res_dtype = dt.Float64(self.dtype.nullable or other_dtype.nullable)
-            for (m, i), (n, j) in zip(self.items(), others):
+            for (m, i), (n, j) in zip(self._items(), others):
                 # TODO Use error handling to mke this more efficient..
                 if m or n:
                     res.append(None)
@@ -1600,7 +1550,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             res_dtype = dt.promote(self.dtype, other_dtype)
             if res_dtype is None:
                 raise TypeError(f"{self.dtype} and {other_dtype} are incompatible")
-            for (m, i), (n, j) in zip(self.items(), others):
+            for (m, i), (n, j) in zip(self._items(), others):
                 if m or n:
                     res.append(None)
                 else:
@@ -1618,7 +1568,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             other_dtype = dt.infer_dtype_from_value(other)
         res_dtype = dt.Boolean(self.dtype.nullable or other_dtype.nullable)
         res = []
-        for (m, i), (n, j) in zip(self.items(), others):
+        for (m, i), (n, j) in zip(self._items(), others):
             if m or n:
                 res.append(None)
             else:
@@ -1644,7 +1594,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     def _accumulate(self, func):
         total = None
         res = Scope._EmptyColumn(self.dtype)
-        for m, i in self.items():
+        for m, i in self._items():
             if m:
                 res._append_null()
             elif total is None:
@@ -1684,3 +1634,62 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                 f"Output of transform must return the same number of rows: got {len(ret)} instead of {length}"
             )
         return ret
+
+    @abc.abstractmethod
+    def _getmask(self, i):
+        """Return mask at index i"""
+        raise self._not_supported("_getmask")
+
+    @abc.abstractmethod
+    def _getdata(self, i):
+        """Return data at index i"""
+        raise self._not_supported("getdata")
+
+    def _get(self, index, fill_value=None):
+        """Return data[index] or fill_value if data[i] not valid"""
+        if self._getmask(index):
+            return fill_value
+        else:
+            return self._getdata(index)
+
+    def _gets(self, indices):
+        """Return a new column with the rows[indices[0]],..,rows[indices[-1]]"""
+        res = Scope._EmptyColumn(self.dtype)
+        for i in indices:
+            (m, d) = (self._getmask(i), self._getdata(i))
+            if m:
+                res._append_null()
+            else:
+                res._append_value(d)
+        return res._finalize()
+
+    def _slice(self, start, stop, step):
+        """Return a new column with the slice rows[start:stop:step]"""
+        res = Scope._EmptyColumn(self.dtype)
+        for i in list(range(len(self)))[start:stop:step]:
+            m = self._getmask(i)
+            if m:
+                res._append_null()
+            else:
+                res._append_value(self._getdata(i))
+        return res._finalize()
+
+    def _items(self):
+        """Iterator returning mask,data pairs for all items of a column"""
+        for i in range(len(self)):
+            yield (self._getmask(i), self._getdata(i))
+
+    def _data_iter(self, fill_value=None):
+        """Iterator returning non-null or fill_value data of a column"""
+        for m, i in self._items():
+            if m:
+                if fill_value is not None:
+                    yield fill_value
+            else:
+                yield i
+
+    # private aggregation functions
+
+    def _count(self):
+        """Return number of non-NA/null observations pgf the column/frame"""
+        return len(self) - self.null_count

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -275,10 +275,10 @@ class IDataFrameVar(Var, IDataFrame):
     def null_count(self):
         return self._not_supported("null_count")
 
-    def getmask(self, i):
-        return self._not_supported("getmask")
+    def _getmask(self, i):
+        return self._not_supported("_getmask")
 
-    def getdata(self, i):
+    def _getdata(self, i):
         return self._not_supported("getdata")
 
     def _set_field_data(self, name: str, col: IColumn, empty_df: bool):

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -17,8 +17,8 @@ class TestDataFrame(unittest.TestCase):
         # testing internals...
         self.assertTrue(isinstance(empty, IDataFrame))
 
-        self.assertEqual(empty.length(), 0)
-        self.assertEqual(empty.null_count(), 0)
+        self.assertEqual(empty.length, 0)
+        self.assertEqual(empty.null_count, 0)
         self.assertEqual(empty.columns, [])
 
     def base_test_internals_full(self):
@@ -29,8 +29,8 @@ class TestDataFrame(unittest.TestCase):
         for i in range(4):
             self.assertEqual(df[i], (i,))
 
-        self.assertEqual(df.length(), 4)
-        self.assertEqual(df.null_count(), 0)
+        self.assertEqual(df.length, 4)
+        self.assertEqual(df.null_count, 0)
         self.assertEqual(list(df), list((i,) for i in range(4)))
         m = df[0 : len(df)]
         self.assertEqual(list(df[0 : len(df)]), list((i,) for i in range(4)))
@@ -39,7 +39,7 @@ class TestDataFrame(unittest.TestCase):
         #     # TypeError: a tuple of type dt.Struct([dt.Field(a, dt.int64)]) is required, got None
         #     df=df.append([None])
         #     self.assertEqual(df.length(), 5)
-        #     self.assertEqual(df.null_count(), 1)
+        #     self.assertEqual(df.null_count, 1)
 
     def base_test_internals_full_nullable(self):
         with self.assertRaises(TypeError):
@@ -63,15 +63,15 @@ class TestDataFrame(unittest.TestCase):
             # but all public APIs report this back as None
 
             self.assertEqual(df[i], None)
-            self.assertEqual(df.valid(i), False)
-            self.assertEqual(df.null_count(), i + 1)
+            self.assertEqual(df.is_valid_at(i), False)
+            self.assertEqual(df.null_count, i + 1)
         for i in [3]:
             df = df.append([(i, i * i)])
             self.assertEqual(df[i], (i, i * i))
-            self.assertEqual(df.valid(i), True)
+            self.assertEqual(df.is_valid_at(i), True)
 
-        self.assertEqual(df.length(), 4)
-        self.assertEqual(df.null_count(), 3)
+        self.assertEqual(df.length, 4)
+        self.assertEqual(df.null_count, 3)
         self.assertEqual(len(df["a"]), 4)
         self.assertEqual(len(df["b"]), 4)
         self.assertEqual(len(df._mask), 4)

--- a/torcharrow/test/test_list_column.py
+++ b/torcharrow/test/test_list_column.py
@@ -14,8 +14,8 @@ class TestListColumn(unittest.TestCase):
         self.assertTrue(isinstance(c, IListColumn))
         self.assertEqual(c.dtype, dt.List(dt.int64))
 
-        self.assertEqual(c.length(), 0)
-        self.assertEqual(c.null_count(), 0)
+        self.assertEqual(c.length, 0)
+        self.assertEqual(c.null_count, 0)
 
     def base_test_nonempty(self):
         c = ta.Column(dt.List(dt.int64), device=self.device)

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -18,7 +18,7 @@ class TestNumericalColumn(unittest.TestCase):
         self.assertTrue(isinstance(empty_i64_column, INumericalColumn))
         self.assertEqual(empty_i64_column.dtype, dt.int64)
         self.assertEqual(len(empty_i64_column), 0)
-        self.assertEqual(empty_i64_column.null_count(), 0)
+        self.assertEqual(empty_i64_column.null_count, 0)
         self.assertEqual(len(empty_i64_column), 0)
 
         return empty_i64_column
@@ -28,7 +28,7 @@ class TestNumericalColumn(unittest.TestCase):
 
         # self.assertEqual(col._offset, 0)
         self.assertEqual(len(col), 4)
-        self.assertEqual(col.null_count(), 0)
+        self.assertEqual(col.null_count, 0)
         self.assertEqual(list(col), list(range(4)))
         m = col[0 : len(col)]
         self.assertEqual(list(m), list(range(4)))
@@ -49,8 +49,8 @@ class TestNumericalColumn(unittest.TestCase):
         col = col.append([3])
         self.assertEqual(col[-1], 3)
 
-        self.assertEqual(col.length(), 4)
-        self.assertEqual(col.null_count(), 3)
+        self.assertEqual(col.length, 4)
+        self.assertEqual(col.null_count, 3)
 
         self.assertEqual(col[0], None)
         self.assertEqual(col[3], 3)

--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -11,8 +11,8 @@ class TestStringColumn(unittest.TestCase):
         empty = ta.Column(dt.string, device=self.device)
         self.assertTrue(isinstance(empty, IStringColumn))
         self.assertEqual(empty.dtype, dt.string)
-        self.assertEqual(empty.length(), 0)
-        self.assertEqual(empty.null_count(), 0)
+        self.assertEqual(empty.length, 0)
+        self.assertEqual(empty.null_count, 0)
         # self.assertEqual(empty._offsets[0], 0)
 
     def base_test_append_offsets(self):

--- a/torcharrow/test/test_trace.py
+++ b/torcharrow/test/test_trace.py
@@ -139,13 +139,11 @@ class TestColumnTrace(unittest.TestCase):
         # simply list all operations and see what happens...
 
         c0 = c0.append([16, 19])
-        _ = c0.count()
         _ = len(c0)
         # _ = c0.ndim
         # _ = c0.size
         # TODO: do we need copy...
         c1 = c0  # .copy()
-        _ = c1.get(0, None)
         s = 0
         for i in c1:
             s += i
@@ -180,7 +178,6 @@ class TestColumnTrace(unittest.TestCase):
             "c1 = torcharrow.icolumn.IColumn.append(c0, [13])",
             "c2 = torcharrow.icolumn.IColumn.append(c1, [14])",
             "c3 = torcharrow.icolumn.IColumn.append(c2, [16, 19])",
-            "_ = torcharrow.icolumn.IColumn.count(c3)",
             "_ = torcharrow.icolumn.IColumn.__getitem__(c3, 0)",
             "c4 = torcharrow.icolumn.IColumn.__getitem__(c3, slice(None, 1, None))",
             "c5 = torcharrow.icolumn.IColumn.__getitem__(c3, [0, 1])",

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -93,15 +93,16 @@ class ListColumnCpu(IListColumn, ColumnFromVelox):
     def __len__(self):
         return len(self._data)
 
+    @property
     def null_count(self):
         return self._data.get_null_count()
 
-    def getmask(self, i):
+    def _getmask(self, i):
         if i < 0:
             i += len(self._data)
         return self._data.is_null_at(i)
 
-    def getdata(self, i):
+    def _getdata(self, i):
         if i < 0:
             i += len(self._data)
         if self._data.is_null_at(i):
@@ -127,13 +128,13 @@ class ListColumnCpu(IListColumn, ColumnFromVelox):
             tablefmt="plain",
             showindex=True,
         )
-        typ = f"dtype: {self._dtype}, length: {self.length()}, null_count: {self.null_count()}"
+        typ = f"dtype: {self._dtype}, length: {self.length()}, null_count: {self.null_count}"
         return tab + dt.NL + typ
 
     def __iter__(self):
         """Return the iterator object itself."""
         for i in range(len(self)):
-            item = self.get(i)
+            item = self._get(i)
             if item is None:
                 yield item
             else:

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -107,15 +107,16 @@ class MapColumnCpu(IMapColumn, ColumnFromVelox):
     def __len__(self):
         return len(self._data)
 
+    @property
     def null_count(self):
         return self._data.get_null_count()
 
-    def getmask(self, i):
+    def _getmask(self, i):
         if i < 0:
             i += len(self._data)
         return self._data.is_null_at(i)
 
-    def getdata(self, i):
+    def _getdata(self, i):
         if i < 0:
             i += len(self._data)
         if self._data.is_null_at(i):
@@ -150,7 +151,7 @@ class MapColumnCpu(IMapColumn, ColumnFromVelox):
             tablefmt="plain",
             showindex=True,
         )
-        typ = f"dtype: {self._dtype}, length: {self.length()}, null_count: {self.null_count()}"
+        typ = f"dtype: {self._dtype}, length: {self.length}, null_count: {self.null_count}"
         return tab + dt.NL + typ
 
 

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -97,15 +97,16 @@ class StringColumnCpu(IStringColumn, ColumnFromVelox):
     def __len__(self):
         return len(self._data)
 
+    @property
     def null_count(self):
         return self._data.get_null_count()
 
-    def getmask(self, i):
+    def _getmask(self, i):
         if i < 0:
             i += len(self._data)
         return self._data.is_null_at(i)
 
-    def getdata(self, i):
+    def _getdata(self, i):
         if i < 0:
             i += len(self._data)
         if self._data.is_null_at(i):
@@ -117,12 +118,12 @@ class StringColumnCpu(IStringColumn, ColumnFromVelox):
     def _valid_mask(ct):
         raise np.full((ct,), False, dtype=np.bool8)
 
-    def gets(self, indices):
+    def _gets(self, indices):
         data = self._data[indices]
         mask = self._mask[indices]
         return self._scope._FullColumn(data, self.dtype, self.device, mask)
 
-    def slice(self, start, stop, step):
+    def _slice(self, start, stop, step):
         range = slice(start, stop, step)
         return self._scope._FullColumn(
             self._data[range], self.dtype, self.device, self._mask[range]
@@ -162,7 +163,7 @@ class StringColumnCpu(IStringColumn, ColumnFromVelox):
             tablefmt="plain",
             showindex=True,
         )
-        typ = f"dtype: {self.dtype}, length: {self.length()}, null_count: {self.null_count()}, device: cpu"
+        typ = f"dtype: {self.dtype}, length: {self.length}, null_count: {self.null_count}, device: cpu"
         return tab + dt.NL + typ
 
 

--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -288,7 +288,7 @@
         "executionStopTime": 1634146945398
       },
       "source": [
-        "len(s), s.count(), s.null_count()\n",
+        "len(s), s._count(), s.null_count\n",
         ""
       ],
       "execution_count": 5,

--- a/tutorial/tutorial.py
+++ b/tutorial/tutorial.py
@@ -64,7 +64,7 @@ s.device
 # In[5]:
 
 
-len(s), s.count(), s.null_count()
+len(s), s._count(), s.null_count
 
 
 # TorchArrow infers Python float as float32 (instead of float64). This follows PyTorch and other deep learning libraries.


### PR DESCRIPTION
Summary:
* Rename `IColumn.isnullable` -> `is_nullable`, as PyArrow API convention is snake case. Mark with EXPERIMENTAL API
* Make `IColumn.length` as property
* Mkae `IColumn.null_count` as property -- consistent with PyArrow
* Move most getter methods to private: `getmask`, `getdata`, `get`, `gets`, `slice`, `items`, `data` -- we are having too many of them and it's quite confusing, and the `__get_item__`  seems to cover all use case (together wit the fact that `IColumn` itself is iterable.
* Rename `IColumn.valid(idx)` to `IColumn.is_valid_at(idx)`. So PyArrow has `is_valid` and `is_null`, but it returns an array indicates each element's validity/nullability. Looks like `is_valid_at(idx)` is the right way to go. Mark it with EXPERIMENTAL API.
* Mark `IColumn.tail()` as EXPERIMENTAL API, since it's not streaming-friendly (and `.head()` should be preferred to use
* Move `IColumn.count()` as private aggregate function. It's confusing to have `count`, `length` and `null_count`.

--------------------------

Note on aggregation function:

In general, the purpose for all these aggregation functions (`min`/`max`/`all`/`any`/`sum`/`prod`/`mean`/`median`/`mode`/`count`) is to to support `groupby` (See https://github.com/facebookresearch/torcharrow/blob/861609fdb5b05a6e2b2952f1ef883f3d2dda217d/torcharrow/velox_rt/dataframe_cpu.py#L2064-L2115, it finally delegates to `IColumn.AGGR_FUNC()`: https://github.com/facebookresearch/torcharrow/blob/861609fdb5b05a6e2b2952f1ef883f3d2dda217d/torcharrow/dtypes.py#L767-L778

TorchArrow indeed intends to support `groupby`, especially streaming aggregation as it's useful in feature preprocessing. However, how to support it is an open question. Especially we also want to support UDAFs. Plus, these global aggregation function is not streaming-friendly. So will move them as private in separate PRs.

Differential Revision: D32041712

