### PR TITLE
Minor cleanup to "cleaning APIs" and "batching APIs"

### DIFF
--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -430,7 +430,7 @@ class TestDataFrame(unittest.TestCase):
         # self.assertEqual(
         #     list(c.radd(f, fill_value=100)), [(i,) for i in [100, 2, 6, 200]]
         # )
-        self.assertEqual(list((c + f).fillna(100)), [(i,) for i in [100, 2, 6, 100]])
+        self.assertEqual(list((c + f).fill_null(100)), [(i,) for i in [100, 2, 6, 100]])
 
         # &, |, ^, ~
         g = ta.Column([True, False, True, False], device=self.device)
@@ -466,8 +466,8 @@ class TestDataFrame(unittest.TestCase):
     def base_test_na_handling(self):
         c = ta.DataFrame({"a": [None, 2, 17.0]}, device=self.device)
 
-        self.assertEqual(list(c.fillna(99.0)), [(i,) for i in [99.0, 2, 17.0]])
-        self.assertEqual(list(c.dropna()), [(i,) for i in [2, 17.0]])
+        self.assertEqual(list(c.fill_null(99.0)), [(i,) for i in [99.0, 2, 17.0]])
+        self.assertEqual(list(c.drop_null()), [(i,) for i in [2, 17.0]])
 
         c = c.append([(2,)])
         self.assertEqual(list(c.drop_duplicates()), [(i,) for i in [None, 2, 17.0]])

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -354,8 +354,8 @@ class TestNumericalColumn(unittest.TestCase):
     def base_test_na_handling(self):
         c = ta.Column([None, 2, 17.0], device=self.device)
 
-        self.assertEqual(c.fillna(99.0), [99.0, 2, 17.0])
-        self.assertEqual(c.dropna(), [2.0, 17.0])
+        self.assertEqual(c.fill_null(99.0), [99.0, 2, 17.0])
+        self.assertEqual(c.drop_null(), [2.0, 17.0])
 
         c = c.append([2])
         self.assertEqual(set(c.drop_duplicates()), {None, 2, 17.0})
@@ -405,7 +405,7 @@ class TestNumericalColumn(unittest.TestCase):
         d = set(c)
         d.add(None)
         self.assertEqual(C.nunique(), len(set(C) - {None}))
-        self.assertEqual(C.nunique(dropna=False), len(set(C)))
+        self.assertEqual(C.nunique(drop_null=False), len(set(C)))
 
         self.assertEqual(C.is_unique(), False)
         self.assertEqual(ta.Column([1, 2, 3], device=self.device).is_unique(), True)

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -1266,7 +1266,7 @@ class DataFrameCpu(IDataFrame, ColumnFromVelox):
 
     @trace
     @expression
-    def fillna(self, fill_value: Union[dt.ScalarTypes, Dict, Literal[None]]):
+    def fill_null(self, fill_value: Union[dt.ScalarTypes, Dict, Literal[None]]):
         if fill_value is None:
             return self
         if isinstance(fill_value, IColumn._scalar_types):
@@ -1279,17 +1279,17 @@ class DataFrameCpu(IDataFrame, ColumnFromVelox):
                         self._data.child_at(i),
                         True,
                     )
-                    .fillna(fill_value)
+                    .fill_null(fill_value)
                     for i in range(self._data.children_size())
                 },
                 self._mask,
             )
         else:
-            raise TypeError(f"fillna with {type(fill_value)} is not supported")
+            raise TypeError(f"fill_null with {type(fill_value)} is not supported")
 
     @trace
     @expression
-    def dropna(self, how: Literal["any", "all"] = "any"):
+    def drop_null(self, how: Literal["any", "all"] = "any"):
         """Return a dataframe with rows removed where the row has any or all nulls."""
         # TODO only flat columns supported...
         assert self._dtype is not None
@@ -1462,7 +1462,7 @@ class DataFrameCpu(IDataFrame, ColumnFromVelox):
 
     @trace
     @expression
-    def nunique(self, dropna=True):
+    def nunique(self, drop_null=True):
         """Returns the number of unique values per column"""
         res = {}
         res["column"] = ta.Column([f.name for f in self.dtype.fields], dt.string)
@@ -1473,7 +1473,7 @@ class DataFrameCpu(IDataFrame, ColumnFromVelox):
                     f.dtype,
                     self._data.child_at(self._data.type().get_child_idx(f.name)),
                     True,
-                ).nunique(dropna)
+                ).nunique(drop_null)
                 for f in self.dtype.fields
             ],
             dt.int64,
@@ -1852,7 +1852,7 @@ class DataFrameCpu(IDataFrame, ColumnFromVelox):
         self,
         by: List[str],
         sort=False,
-        dropna=True,
+        drop_null=True,
     ):
         """
         SQL like data grouping, supporting split-apply-combine paradigm.
@@ -1865,7 +1865,7 @@ class DataFrameCpu(IDataFrame, ColumnFromVelox):
         sort - bool
             Whether the groups are in sorted order.
 
-        dropna - bool
+        drop_null - bool
             Whether NULL/NaNs in group keys are dropped.
 
         Examples
@@ -1923,7 +1923,7 @@ class DataFrameCpu(IDataFrame, ColumnFromVelox):
         """
         # TODO implement
         assert not sort
-        assert dropna
+        assert drop_null
         self._check_columns(by)
 
         key_columns = by

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -213,12 +213,12 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
 
     @trace
     @expression
-    def nunique(self, dropna=True):
+    def nunique(self, drop_null=True):
         """Returns the number of unique values of the column"""
         result = set()
         for i in range(len(self)):
             if self._getmask(i):
-                if not dropna:
+                if not drop_null:
                     result.add(None)
             else:
                 result.add(self._getdata(i))
@@ -655,10 +655,10 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
 
     @trace
     @expression
-    def fillna(self, fill_value: Union[dt.ScalarTypes, Dict]):
+    def fill_null(self, fill_value: Union[dt.ScalarTypes, Dict]):
         """Fill NA/NaN values using the specified method."""
         if not isinstance(fill_value, IColumn._scalar_types):
-            raise TypeError(f"fillna with {type(fill_value)} is not supported")
+            raise TypeError(f"fill_null with {type(fill_value)} is not supported")
         if not self.is_nullable:
             return self
         else:
@@ -675,7 +675,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
 
     @trace
     @expression
-    def dropna(self, how: Literal["any", "all"] = "any"):
+    def drop_null(self, how: Literal["any", "all"] = "any"):
         """Return a column with rows removed where a row has any or all nulls."""
         if not self.is_nullable:
             return self
@@ -882,7 +882,7 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     @expression
     def is_unique(self):
         """Return boolean if data values are unique."""
-        return self.nunique(dropna=False) == len(self)
+        return self.nunique(drop_null=False) == len(self)
 
     @trace
     @expression

--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -1185,7 +1185,7 @@
       },
       "source": [
         "## Missing data\n",
-        " Missing data can be filled in via the `fillna` method "
+        " Missing data can be filled in via the `fill_null` method "
       ]
     },
     {
@@ -1198,7 +1198,7 @@
         "executionStopTime": 1634146947576
       },
       "source": [
-        "t = s.fillna(999)\n",
+        "t = s.fill_null(999)\n",
         "t"
       ],
       "execution_count": 27,
@@ -1234,7 +1234,7 @@
         "executionStopTime": 1634146947680
       },
       "source": [
-        "s.dropna()"
+        "s.drop_null()"
       ],
       "execution_count": 28,
       "outputs": [
@@ -1371,7 +1371,7 @@
         "hidden_ranges": []
       },
       "source": [
-        "If null strictness does not work for your code you could call first `fillna` to provide a value that is used instead of null. "
+        "If null strictness does not work for your code you could call first `fill_null` to provide a value that is used instead of null. "
       ]
     },
     {

--- a/tutorial/tutorial.py
+++ b/tutorial/tutorial.py
@@ -285,12 +285,12 @@ df[df["a"].isin([5])]
 
 
 # ## Missing data
-#  Missing data can be filled in via the `fillna` method
+#  Missing data can be filled in via the `fill_null` method
 
 # In[27]:
 
 
-t = s.fillna(999)
+t = s.fill_null(999)
 t
 
 
@@ -299,7 +299,7 @@ t
 # In[28]:
 
 
-s.dropna()
+s.drop_null()
 
 
 # ## Operators
@@ -338,7 +338,7 @@ v = ta.Column([11, None, None])
 u + v
 
 
-# If null strictness does not work for your code you could call first `fillna` to provide a value that is used instead of null.
+# If null strictness does not work for your code you could call first `fill_null` to provide a value that is used instead of null.
 
 # ## Numerical columns and descriptive statistics
 # Numerical columns also support lifted operations, for `abs`, `ceil`, `floor`, `round`. Even more excited might be to use their aggregation operators like `count`, `sum`, `prod`, `min`, `max`, or descriptive statistics like `std`, `mean`, `median`, and `mode`. Here is an example ensemble:


### PR DESCRIPTION
Summary:
* Mark `batching/unbatching` as experimental API
* fillna -> fill_null
* dropna -> drop_null

To be consistent with PyArrow API (plus today's behavior only drops null but not nan).

Also note the semantic of `df.drop_duplicates(subset)` is similar to the following SQL aggregation:
```SQL
SELECT col1, col2, ARBITRARY(col3), ARBITRARY(col4)
FROM ...
GROUP BY col1, col2
```
here `col1`, `col2` are in `subset`; `col3`, `col4` are the rest columns.

Differential Revision: D32051423

