### PR TITLE
Add docstring and tests for DataFrame construction from tuple data

### DIFF
--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -56,6 +56,13 @@ def DataFrame(
         where possible.  Should be a dt.Struct() providing a list of
         dt.Fields.
 
+    columns: list of strings, default None
+        The name of columns. Used when data is a list of tuples without a custom
+        dtype provided. len(columns) should be equal to len(data[0]). When data
+        is a list of tuples and dtype is provided this will be ignored.
+        This should be left to be None when data and dtype are both None (the
+        semantic is constructing a default empty DataFrame without any columns).
+
     device: Device, default ""
         Device selects which runtime to use from scope.  TorchArrow supports
         multiple runtimes (CPU and GPU).  If not supplied, uses the Velox
@@ -119,6 +126,16 @@ def DataFrame(
     >>> import torcharrow.dtypes as dt
     >>> l = [(1, 'a'), (2, 'b'), (3, 'c')]
     >>> ta.DataFrame(l, dtype = dt.Struct([dt.Field('t1', dt.int64), dt.Field('t2', dt.string)]))
+      index    t1  t2
+    -------  ----  ----
+          0     1  a
+          1     2  b
+          2     3  c
+    dtype: Struct([Field('t1', int64), Field('t2', string)]), count: 3, null_count: 0
+
+    or
+
+    >>> ta.DataFrame(l, columns=['t1', 't2'])
       index    t1  t2
     -------  ----  ----
           0     1  a

--- a/torcharrow/scope.py
+++ b/torcharrow/scope.py
@@ -325,7 +325,11 @@ but data only provides {len(data)} fields: {data.keys()}
                 if dtype is None or not dt.is_tuple(dtype):
                     raise TypeError("Dataframe cannot infer struct type from data")
                 dtype = ty.cast(dt.Tuple, dtype)
-                columns = [] if columns is None else columns
+                if columns is None:
+                    raise TypeError(
+                        "DataFrame construction from tuples requires"
+                        " dtype or columns to be given"
+                    )
                 if len(dtype.fields) != len(columns):
                     raise TypeError("Dataframe column length must equal row length")
                 dtype = dt.Struct(

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -173,6 +173,29 @@ class TestDataFrame(unittest.TestCase):
         self.assertEqual(list(df), list(zip(*data3.values())))
         self.assertEqual(df.dtype, dtype3)
 
+        data4 = [(1, "a"), (2, "b"), (3, "c")]
+        columns4 = ["t1", "t2"]
+        dtype4 = dt.Struct(
+            [
+                dt.Field("t1", dt.int64),
+                dt.Field("t2", dt.string),
+            ]
+        )
+        # DataFrame construction from tuple data requires dtype or columns
+        # provided to tell the column names
+        with self.assertRaises(TypeError) as ex:
+            df = ta.DataFrame(data4, device=self.device)
+        self.assertTrue(
+            "DataFrame construction from tuples requires" in str(ex.exception),
+            f"Excpeion message is not as expected: {str(ex.exception)}",
+        )
+        df4 = ta.DataFrame(data4, columns=columns4)
+        self.assertEqual(list(df4), data4)
+        self.assertEqual(df4.dtype, dtype4)
+        df4 = ta.DataFrame(data4, dtype=dtype4)
+        self.assertEqual(list(df4), data4)
+        self.assertEqual(df4.dtype, dtype4)
+
     def base_test_infer(self):
         df = ta.DataFrame({"a": [1, 2, 3], "b": [1.0, None, 3]}, device=self.device)
         self.assertEqual(df.columns, ["a", "b"])


### PR DESCRIPTION
Summary:
In addition to using `dtype` we can also use `columns` to inform the column names when constructing DataFrame from tuple data
```
ta.DataFrame([(1,'a'), (2,'b')], columns=['t1', 't2'])
```

Differential Revision: D32142919

