### PR TITLE
Minor change to copy/concat API

### DIFF
--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -11,7 +11,8 @@ from .trace import *  # dependencies: expression
 from .scope import *  # dependencies: column_factory, dtypes
 
 # following needs scope*
-from .icolumn import *  # dependencies: cyclic dependency to every other column
+from .icolumn import Column
+from .icolumn import concat  # noqa
 from .inumerical_column import *
 from .istring_column import *
 from .ilist_column import *

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -205,6 +205,10 @@ class IDataFrame(IColumn):
         self._set_field_data(name, col, empty_df)
 
     @trace
+    def copy(self):
+        raise self._not_supported("copy")
+
+    @trace
     @expression
     def transform(
         self,
@@ -305,6 +309,10 @@ class IDataFrameVar(Var, IDataFrame):
 
     def _set_field_data(self, name: str, col: IColumn, empty_df: bool):
         raise self._not_supported("_set_field_data")
+
+    def _concat_with(self, columns: List[IColumn]):
+        """Returns concatenated columns."""
+        raise self._not_supported("_concat_with")
 
     @property  # type: ignore
     def columns(self):

--- a/torcharrow/test/test_list_column.py
+++ b/torcharrow/test/test_list_column.py
@@ -36,11 +36,11 @@ class TestListColumn(unittest.TestCase):
         self.assertEqual(list(sf2), base_list + append1)
 
         append2 = [["I", "am", "fine", "too"]]
-        sf3 = sf2.concat([ta.Column(append2, device=self.device)])
+        sf3 = ta.concat([sf2, ta.Column(append2, device=self.device)])
         self.assertEqual(list(sf3), base_list + append1 + append2)
 
         # concat everything
-        sf_all = sf1.concat([sf2, sf3])
+        sf_all = ta.concat([sf1, sf2, sf3])
         self.assertEqual(list(sf_all), list(sf1) + list(sf2) + list(sf3))
 
     def base_test_nested_numerical_twice(self):

--- a/torcharrow/velox_rt/column.py
+++ b/torcharrow/velox_rt/column.py
@@ -1,11 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import typing as ty
+
 import torcharrow._torcharrow as velox
 from torcharrow import Scope
 from torcharrow.dispatcher import Device
 from torcharrow.dtypes import DType
 from torcharrow.icolumn import IColumn
 
-
+# TODO: Rename this class to IColumnVelox or IColumnCpu
 class ColumnFromVelox:
     _data: velox.BaseColumn
     _finialized: bool
@@ -24,7 +26,16 @@ class ColumnFromVelox:
 
     # Velox column returned from generic dispatch always assumes returned column is nullable
     # This help method allows to alter it based on context (e.g. methods in IStringMethods can have better inference)
+    #
+    # TODO: rename this as _with_null as alternating nullability is dangerous.
+    #   We should also infer the type nullability flag better with function metadata on Velox.
     def with_null(self, nullable: bool):
         return self.from_velox(
             self.device, self.dtype.with_null(nullable), self._data, True
         )
+
+    def _concat_with(self, columns: ty.List[IColumn]):
+        concat_list = self.to_pylist()
+        for column in columns:
+            concat_list += column.to_pylist()
+        return Scope._FromPyList(concat_list, self.dtype)

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -55,12 +55,12 @@ from .typing import get_velox_type
 DataOrDTypeOrNone = Union[Mapping, Sequence, dt.DType, Literal[None]]
 
 
-class DataFrameCpu(IDataFrame, ColumnFromVelox):
+class DataFrameCpu(ColumnFromVelox, IDataFrame):
     """Dataframe, ordered dict of typed columns of the same length"""
 
     def __init__(self, device, dtype, data):
         assert dt.is_struct(dtype)
-        super().__init__(device, dtype)
+        IDataFrame.__init__(self, device, dtype)
 
         self._data = velox.Column(get_velox_type(dtype))
         assert isinstance(data, dict)

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -19,12 +19,12 @@ from .typing import get_velox_type
 # IListColumn
 
 
-class ListColumnCpu(IListColumn, ColumnFromVelox):
+class ListColumnCpu(ColumnFromVelox, IListColumn):
 
     # private constructor
     def __init__(self, device, dtype, data, offsets, mask):
         assert dt.is_list(dtype)
-        super().__init__(device, dtype)
+        IListColumn.__init__(self, device, dtype)
 
         self._data = velox.Column(
             velox.VeloxArrayType(get_velox_type(dtype.item_dtype))

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -23,10 +23,10 @@ from .typing import get_velox_type
 # IMapColumn
 
 
-class MapColumnCpu(IMapColumn, ColumnFromVelox):
+class MapColumnCpu(ColumnFromVelox, IMapColumn):
     def __init__(self, device, dtype, key_data, item_data, mask):
         assert dt.is_map(dtype)
-        super().__init__(device, dtype)
+        IMapColumn.__init__(self, device, dtype)
 
         self._data = velox.Column(
             velox.VeloxMapType(

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -22,14 +22,14 @@ from .typing import get_velox_type
 # ------------------------------------------------------------------------------
 
 
-class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
+class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     """A Numerical Column"""
 
     # private
     def __init__(self, device, dtype, data, mask):
         # TODO: Refactor the constructors (remove mask, data should be velox.BaseColumn)
         assert dt.is_boolean_or_numerical(dtype)
-        super().__init__(device, dtype)
+        INumericalColumn.__init__(self, device, dtype)
         self._data = velox.Column(get_velox_type(dtype))
         for m, d in zip(mask.tolist(), data.tolist()):
             if m:
@@ -100,10 +100,6 @@ class NumericalColumnCpu(INumericalColumn, ColumnFromVelox):
     def null_count(self):
         """Return number of null items"""
         return self._data.get_null_count()
-
-    @trace
-    def copy(self):
-        return Scope._FullColumn(self._data.copy(), self.mask.copy())
 
     def _getdata(self, i):
         if i < 0:

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -21,12 +21,12 @@ from .typing import get_velox_type
 # StringColumnCpu
 
 
-class StringColumnCpu(IStringColumn, ColumnFromVelox):
+class StringColumnCpu(ColumnFromVelox, IStringColumn):
 
     # private constructor
     def __init__(self, device, dtype, data, mask):  # REP offsets
         assert dt.is_string(dtype)
-        super().__init__(device, dtype)
+        IStringColumn.__init__(self, device, dtype)
 
         self._data = velox.Column(get_velox_type(dtype))
         for m, d in zip(mask.tolist(), data):


### PR DESCRIPTION
Summary:
1. Remove IColumn.copy since TorchArrow column is immutable, move it into IDataFrame.copy.
2. Move IColumn.concat to torcharrow.concat
    * Pandas only has pandas.concat
    * Pandas's Series.append only accpet Series as parameter.
    * I think it makes sense to IColumn.append to support both Python list and Column as input. But not have both IColumn.append and IColumn.concat

Differential Revision: D32185907

