### PR TITLE
fix the incorrect type inference of np.float64

### DIFF
--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -568,10 +568,10 @@ def infer_dtype_from_value(value):
         return prt(value, boolean)
     if isinstance(value, (int, np.integer)):
         return prt(value, int64)
-    if isinstance(value, (float, np.float32)):
-        return prt(value, float32)
     if isinstance(value, np.float64):
         return prt(value, float64)
+    if isinstance(value, (float, np.float32)):
+        return prt(value, float32)
     if isinstance(value, (str, np.str_)):
         return prt(value, string)
     if isinstance(value, list):


### PR DESCRIPTION
Summary: Previously the infer dtype of np.Float64 was dt.Float32, it was incorrect because  np.float64 is considered as an instance of float, hence the `infer_dtype_from_value` method would treat it as float32

Differential Revision: D32435399

