### PR TITLE
Initialize default Scope in TestDFNoTrace

### DIFF
--- a/torcharrow/test/test_trace.py
+++ b/torcharrow/test/test_trace.py
@@ -45,6 +45,9 @@ class DF:
 
 
 class TestDFNoTrace(unittest.TestCase):
+    def setUp(self):
+        Scope.default = Scope()
+
     def test_tracing_off(self):
         trace = Scope.default.trace
 


### PR DESCRIPTION
Otherwise the test run with
```
python -m unittest -v
```

would fail.