### PR TITLE
fix the incorrect type inference of np.int32

### DIFF
--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -566,6 +566,8 @@ def infer_dtype_from_value(value):
         return Void()
     if isinstance(value, (bool, np.bool8)):
         return prt(value, boolean)
+    if isinstance(value, (np.int32)):
+        return prt(value, int32)
     if isinstance(value, (int, np.integer)):
         return prt(value, int64)
     if isinstance(value, np.float64):

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -112,6 +112,12 @@ class TestNumericalColumn(unittest.TestCase):
         c = ta.Column([1], device=self.device)
         self.assertEqual(c.dtype, dt.int64)
         self.assertEqual(list(c), [1])
+        c = ta.Column([np.int64(2)], device=self.device)
+        self.assertEqual(c.dtype, dt.int64)
+        self.assertEqual(list(c), [2])
+        c = ta.Column([np.int32(3)], device=self.device)
+        self.assertEqual(c.dtype, dt.int32)
+        self.assertEqual(list(c), [3])
 
         # bool
         c = ta.Column([True, None], device=self.device)


### PR DESCRIPTION
Summary: Previously the infered dtype of np.int32 was dt.int64 because the infer_dtype_from_value didn't handle such case

Differential Revision: D32467719

