### PR TITLE
Add _fromarrow support for primitive types

### DIFF
--- a/csrc/velox/column.h
+++ b/csrc/velox/column.h
@@ -7,14 +7,15 @@
 #include <unordered_map>
 #include "vector.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/core/QueryCtx.h"
-#include "velox/common/base/Exceptions.h"
 #include "velox/expression/Expr.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
+#include "velox/vector/arrow/Bridge.h"
 
 // TODO: Move uses of static variables into .cpp. Static variables are local to
 // the compilation units so every file that includes this header will have its
@@ -601,8 +602,8 @@ class SimpleColumn : public BaseColumn {
 
     const static auto inputRowType =
         velox::ROW({"c0"}, {velox::CppToType<T>::create()});
-    const static auto op = OperatorHandle::fromGenericUDF(
-        inputRowType, "torcharrow_isinteger");
+    const static auto op =
+        OperatorHandle::fromGenericUDF(inputRowType, "torcharrow_isinteger");
     return op->call({_delegate});
   }
 

--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -21,7 +21,7 @@ from .idataframe import *
 from .velox_rt import *
 
 from . import pytorch
-from .interop import from_pylist
+from .interop import from_pylist, from_arrow
 
 try:
     from .version import __version__  # noqa: F401

--- a/torcharrow/test/test_arrow_interop.py
+++ b/torcharrow/test/test_arrow_interop.py
@@ -1,0 +1,81 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import math
+import unittest
+
+import pyarrow as pa
+import torcharrow as ta
+import torcharrow.dtypes as dt
+
+
+class TestArrowInterop(unittest.TestCase):
+    def base_test_arrow_array(self):
+        s = pa.array([1, 2, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Int64(True))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        s = pa.array([1.0, math.nan, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Float64(True))
+        for i, j in zip([i.as_py() for i in s], list(t)):
+            if math.isnan(i) and math.isnan(j):
+                pass
+            else:
+                self.assertEqual(i, j)
+
+        s = pa.array([1.0, None, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Float64(True))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        s = pa.array([1, 2, 3], type=pa.int16())
+        t = ta.from_arrow(s, dtype=dt.Int16(False), device=self.device)
+        self.assertEqual(t.dtype, dt.Int16(False))
+        self.assertEqual(
+            [i.as_py() for i in s],
+            list(t),
+        )
+
+        s = pa.array([True, False, True])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Boolean(True))
+        self.assertEqual(
+            [i.as_py() for i in s], list(ta.from_arrow(s, device=self.device))
+        )
+
+        s = pa.array(["a", "b", "c", "d", "e", "f", "g"])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.String(True))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        # TODO Test that nested types and other unsupported types are error-ed out
+
+    def base_test_ownership_transferred(self):
+        pydata = [1, 2, 3]
+        s = pa.array(pydata)
+        t = ta.from_arrow(s)
+        del s
+        # Check that the data are still around
+        self.assertEqual(pydata, list(t))
+
+    def base_test_memory_reclaimed(self):
+        initial_memory = pa.total_allocated_bytes()
+
+        s = pa.array([1, 2, 3])
+        memory_checkpoint_1 = pa.total_allocated_bytes()
+        self.assertGreater(memory_checkpoint_1, initial_memory)
+
+        # Extra memory are allocated when exporting Arrow data, for the new
+        # ArrowArray and ArrowSchema objects and the private_data inside the
+        # objects
+        t = ta.from_arrow(s)
+        memory_checkpoint_2 = pa.total_allocated_bytes()
+        self.assertGreater(memory_checkpoint_2, memory_checkpoint_1)
+
+        # Deleting the pyarrow array should not release any memory since the
+        # buffers are now owned by the TA column
+        del s
+        self.assertEqual(pa.total_allocated_bytes(), memory_checkpoint_2)
+
+        del t
+        self.assertEqual(pa.total_allocated_bytes(), initial_memory)

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+from .test_arrow_interop import TestArrowInterop
+
+
+class TestArrowInteropCpu(TestArrowInterop):
+    def setUp(self):
+        self.device = "cpu"
+
+    def test_arrow_array(self):
+        return self.base_test_arrow_array()
+
+    def test_ownership_transferred(self):
+        return self.base_test_ownership_transferred()
+
+    def test_memory_reclaimed(self):
+        return self.base_test_memory_reclaimed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torcharrow/test/test_interop.py
+++ b/torcharrow/test/test_interop.py
@@ -6,51 +6,9 @@ import pyarrow as pa
 import torcharrow as ta
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as tap
-from torcharrow.scope import Scope
 
 
 class TestInterop(unittest.TestCase):
-    def base_test_arrow_array(self):
-        s = pa.array([1, 2, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual([i.as_py() for i in s], list(t))
-
-        s = pa.array([1.0, np.nan, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Float64(False))
-        # can't compare nan, so
-
-        for i, j in zip([i.as_py() for i in s], list(t)):
-            if np.isnan(i) and np.isnan(j):
-                pass
-            else:
-                self.assertEqual(i, j)
-
-        s = pa.array([1.0, None, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Float64(True))
-        self.assertEqual([i.as_py() for i in s], list(t))
-
-        s = pa.array([1, 2, 3], type=pa.uint32())
-        self.assertEqual(
-            [i.as_py() for i in s], list(self.ts.from_arrow(s, dt.Int16(False)))
-        )
-
-        s = pa.array([1, 2, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Int64(False))
-        self.assertEqual([i.as_py() for i in s], list(self.ts.from_arrow(s)))
-
-        s = pa.array([True, False, True])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Boolean(False))
-        self.assertEqual([i.as_py() for i in s], list(self.ts.from_arrow(s)))
-
-        s = pa.array(["a", "b", "c", "d", "e", "f", "g"])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.String(False))
-        self.assertEqual([i.as_py() for i in s], list(t))
-
     def base_test_to_pytorch(self):
         import torch
 

--- a/torcharrow/test/test_interop_cpu.py
+++ b/torcharrow/test/test_interop_cpu.py
@@ -14,10 +14,6 @@ class TestInteropCpu(TestInterop):
     def setUp(self):
         self.device = "cpu"
 
-    def test_arrow_array(self):
-        # TODO: support arrow interop in CPU backend
-        pass
-
     @unittest.skipUnless(tap.available, "Requires PyTorch")
     def test_to_pytorch(self):
         return self.base_test_to_pytorch()

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -49,6 +49,34 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
             True,
         )
 
+    @staticmethod
+    def _fromarrow(device: str, array, dtype: dt.DType):
+        import pyarrow as pa
+        from pyarrow.cffi import ffi
+
+        assert isinstance(array, pa.Array)
+
+        c_schema = ffi.new("struct ArrowSchema*")
+        ptr_schema = int(ffi.cast("uintptr_t", c_schema))
+        c_array = ffi.new("struct ArrowArray*")
+        ptr_array = int(ffi.cast("uintptr_t", c_array))
+        array._export_to_c(ptr_array, ptr_schema)
+
+        velox_column = velox._import_from_arrow(
+            get_velox_type(dtype), ptr_array, ptr_schema
+        )
+
+        # Make sure the ownership of c_schema and c_array have been transferred
+        # to velox_column
+        assert c_schema.release == ffi.NULL and c_array.release == ffi.NULL
+
+        return ColumnFromVelox.from_velox(
+            device,
+            dtype,
+            velox_column,
+            True,
+        )
+
     def _append_null(self):
         if self._finialized:
             raise AttributeError("It is already finialized.")
@@ -879,3 +907,6 @@ _primitive_types: List[dt.DType] = [
 for t in _primitive_types:
     Dispatcher.register((t.typecode + "_empty", "cpu"), NumericalColumnCpu._empty)
     Dispatcher.register((t.typecode + "_fromlist", "cpu"), NumericalColumnCpu._fromlist)
+    Dispatcher.register(
+        (t.typecode + "_fromarrow", "cpu"), NumericalColumnCpu._fromarrow
+    )

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -80,6 +80,16 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
             True,
         )
 
+    # TODO Add native kernel support
+    @staticmethod
+    def _fromarrow(device: str, array, dtype: dt.DType):
+        import pyarrow as pa
+
+        assert isinstance(array, pa.Array)
+
+        pydata = [i.as_py() for i in array]
+        return StringColumnCpu._fromlist(device, pydata, dtype)
+
     def _append_null(self):
         if self._finialized:
             raise AttributeError("It is already finialized.")
@@ -342,6 +352,9 @@ Dispatcher.register((dt.String.typecode + "_empty", "cpu"), StringColumnCpu._emp
 Dispatcher.register((dt.String.typecode + "_full", "cpu"), StringColumnCpu._full)
 Dispatcher.register(
     (dt.String.typecode + "_fromlist", "cpu"), StringColumnCpu._fromlist
+)
+Dispatcher.register(
+    (dt.String.typecode + "_fromarrow", "cpu"), StringColumnCpu._fromarrow
 )
 
 


### PR DESCRIPTION
Summary:
Add _fromarrow support for primitive types, including boolean, signed integer types, floating types, and string. The support for numerical types are true zero-copy interop, by integrating Velox's Arrow interop support.

The support for string Arrow interop is implemented by copying the data in the Arrow buffer into a new Velox column so is not zero-copy. This will need to be pushed down to Velox layer to achieve true zero-copy interop but adding it now since it will enable many use cases.

Reference for the cffi technique used to pass C++ pointers between Python and C++: https://github.com/facebookresearch/torcharrow/wiki/Arrow-Velox-zero-copy-conversion

Differential Revision: D32290990

