### PR TITLE
Prevent coercion of IColumn to boolean.

### DIFF
--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -986,6 +986,13 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         """Vectorized: +a."""
         return self._vectorize(operator.pos, self.dtype)
 
+    def __bool__(self):
+        """Prevent accidental coercion of a column to a boolean value"""
+        raise ValueError(
+            f"The truth value of a {type(self).__name__} is ambiguous. "
+            "Use a.any() or a.all()."
+        )
+
     @trace
     @expression
     def isin(self, values: ty.Union[list, dict]):

--- a/torcharrow/test/test_map_column.py
+++ b/torcharrow/test/test_map_column.py
@@ -56,7 +56,7 @@ class TestMapColumn(unittest.TestCase):
 
         self.assertEqual(list(c.maps.keys()), [["abc"], ["de", "fg"], []])
         self.assertEqual(list(c.maps.values()), [[123], [45, 67], []])
-        self.assertEqual(c.maps.get("de", 0), [0, 45, None])
+        self.assertEqual(list(c.maps.get("de", 0)), [0, 45, None])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
This changes prevents accidental use of a column / dataframe
in a boolean context. https://github.com/facebookresearch/torcharrow/pull/77 fixed most of these, but I found some
more lurking in the tests that became obvious failures with this
change.

Differential Revision: D32637402

