### PR TITLE
Add transformation-only test that works for multiple runtime

### DIFF
--- a/torcharrow/test/transformation/test_numeric_ops.py
+++ b/torcharrow/test/transformation/test_numeric_ops.py
@@ -1,0 +1,37 @@
+import unittest
+
+import torcharrow as ta
+
+# TODO: add/migrate more numeric tests
+class _TestNumericOpsBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Prepare input data as CPU dataframe
+        cls.base_df = ta.DataFrame({"c": [0, 1, 3], "d": [5, 5, 6], "e": [1.0, 1, 7]})
+
+        cls.setUpTestCaseData()
+
+    @classmethod
+    def setUpTestCaseData(cls):
+        # Override in subclass
+        # Python doesn't have native "abstract base test" support.
+        # So use unittest.SkipTest to skip in base class: https://stackoverflow.com/a/59561905.
+        raise unittest.SkipTest("abstract base test")
+
+    def test_add(self):
+        c = type(self).df["c"]
+        d = type(self).df["d"]
+
+        self.assertEqual(list(c + 1), [1, 2, 4])
+        self.assertEqual(list(1 + c), [1, 2, 4])
+        self.assertEqual(list(c + d), [5, 6, 9])
+
+
+class TestNumericOpsCpu(_TestNumericOpsBase):
+    @classmethod
+    def setUpTestCaseData(cls):
+        cls.df = cls.base_df.copy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -187,6 +187,9 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
     def _valid_mask(ct):
         return np.full((ct,), False, dtype=np.bool8)
 
+    def copy(self):
+        return ColumnFromVelox.from_velox(self.device, self.dtype, self._data, True)
+
     def append(self, values: Iterable[Union[None, dict, tuple]]):
         """Returns column/dataframe with values appended."""
         it = iter(values)


### PR DESCRIPTION
Summary:
This allows write unified test across eager and lazy (or tracing-based) runtime.

Some runtime may only support transformation across columns from the same dataframe, thus the existing eager mode tests (which creates Column and test them) doesn't work.

The idea is test data is stored in base test class as a CPU dataframe.  And the concrete backend test will convert the CPU dataframe to backend specific dataframe for testing (e.g. GPU or even lazy df) and assert the dataframe transformation has the same behavior.

Python doesn't have native "abstract base test" support. So use this `Raise unittest.SkipTest` trick: https://stackoverflow.com/a/59561905.

Another approach is similar to existing TorchArrow test setup, have `base_test_X` and let subclass to override as `test_X`.

Reviewed By: bhuang3

Differential Revision: D32337291

