### PR TITLE
Test all supported types and error for unsupported types

### DIFF
--- a/torcharrow/_interop.py
+++ b/torcharrow/_interop.py
@@ -244,14 +244,6 @@ def _arrowtype_to_dtype(t, nullable):
         return dt.Float32(nullable)
     if pa.types.is_float64(t):
         return dt.Float64(nullable)
-    if pa.types.is_list(t):
-        return List(t.value_type, nullable)
-    if pa.types.is_struct(t):
-        return _pandatype_to_dtype(t.to_pandas_dtype(), True)
-    if pa.types.is_null(t):
-        return dt.Void()
-    if pa.types.is_string(t):
+    if pa.types.is_string(t) or pa.types.is_large_string(t):
         return dt.String(nullable)
-    if pa.types.is_map(t):
-        return dt.Map(t.item_type, t.key_type, nullable)
-    raise NotImplementedError("unsupported case")
+    raise NotImplementedError(f"Unsupported Arrow type: {str(t)}")

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -17,6 +17,9 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_memory_reclaimed(self):
         return self.base_test_memory_reclaimed()
 
+    def test_unsupported_types(self):
+        return self.base_test_unsupported_types()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Test Arrow Array -> TorchArrow Column import for all supported types.

Error out when the Arrow type is not supported.

At the point of this commit we have native zero-copy support for numeric types and boolean, and have make-a-copy-in-Python-land support for strings.

Differential Revision: D32659641

