### PR TITLE
Tweaking nullability setting in from_arrow

### DIFF
--- a/csrc/velox/column.h
+++ b/csrc/velox/column.h
@@ -7,14 +7,15 @@
 #include <unordered_map>
 #include "vector.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/core/QueryCtx.h"
-#include "velox/common/base/Exceptions.h"
 #include "velox/expression/Expr.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
+#include "velox/vector/arrow/Bridge.h"
 
 // TODO: Move uses of static variables into .cpp. Static variables are local to
 // the compilation units so every file that includes this header will have its
@@ -601,8 +602,8 @@ class SimpleColumn : public BaseColumn {
 
     const static auto inputRowType =
         velox::ROW({"c0"}, {velox::CppToType<T>::create()});
-    const static auto op = OperatorHandle::fromGenericUDF(
-        inputRowType, "torcharrow_isinteger");
+    const static auto op =
+        OperatorHandle::fromGenericUDF(inputRowType, "torcharrow_isinteger");
     return op->call({_delegate});
   }
 

--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -21,7 +21,7 @@ from .idataframe import *
 from .velox_rt import *
 
 from . import pytorch
-from .interop import from_pylist
+from .interop import from_pylist, from_arrow
 
 try:
     from .version import __version__  # noqa: F401

--- a/torcharrow/_interop.py
+++ b/torcharrow/_interop.py
@@ -244,14 +244,6 @@ def _arrowtype_to_dtype(t, nullable):
         return dt.Float32(nullable)
     if pa.types.is_float64(t):
         return dt.Float64(nullable)
-    if pa.types.is_list(t):
-        return List(t.value_type, nullable)
-    if pa.types.is_struct(t):
-        return _pandatype_to_dtype(t.to_pandas_dtype(), True)
-    if pa.types.is_null(t):
-        return dt.Void()
-    if pa.types.is_string(t):
+    if pa.types.is_string(t) or pa.types.is_large_string(t):
         return dt.String(nullable)
-    if pa.types.is_map(t):
-        return dt.Map(t.item_type, t.key_type, nullable)
-    raise NotImplementedError("unsupported case")
+    raise NotImplementedError(f"Unsupported Arrow type: {str(t)}")

--- a/torcharrow/test/test_arrow_interop.py
+++ b/torcharrow/test/test_arrow_interop.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import math
 import unittest
+from typing import List, Tuple
 
 import pyarrow as pa
 import torcharrow as ta
@@ -8,47 +9,76 @@ import torcharrow.dtypes as dt
 
 
 class TestArrowInterop(unittest.TestCase):
-    def base_test_arrow_array(self):
-        s = pa.array([1, 2, 3])
-        t = ta.from_arrow(s, device=self.device)
-        self.assertEqual(t.dtype, dt.Int64(True))
-        self.assertEqual([i.as_py() for i in s], list(t))
+    supported_types: Tuple[Tuple[pa.DataType, dt.DType], ...] = (
+        (pa.bool_(), dt.Boolean(True)),
+        (pa.int8(), dt.Int8(True)),
+        (pa.int16(), dt.Int16(True)),
+        (pa.int32(), dt.Int32(True)),
+        (pa.int64(), dt.Int64(True)),
+        (pa.float32(), dt.Float32(True)),
+        (pa.float64(), dt.Float64(True)),
+        (pa.string(), dt.String(True)),
+        (pa.large_string(), dt.String(True)),
+    )
 
-        s = pa.array([1.0, math.nan, 3])
+    unsupported_types: Tuple[pa.DataType, ...] = (
+        pa.null(),
+        pa.uint8(),
+        pa.uint16(),
+        pa.uint32(),
+        pa.uint64(),
+        pa.time32("s"),
+        pa.time64("us"),
+        pa.timestamp("s"),
+        pa.date32(),
+        pa.date64(),
+        pa.duration("s"),
+        pa.float16(),
+        pa.binary(),
+        pa.large_binary(),
+        pa.decimal128(38),
+        pa.list_(pa.int64()),
+        pa.large_list(pa.int64()),
+        pa.map_(pa.int64(), pa.int64()),
+        pa.struct([pa.field("f1", pa.int64())]),
+        pa.dictionary(pa.int64(), pa.int64()),
+        # Union type needs to be tested differently
+    )
+
+    def _test_construction_numeric(
+        self, pydata: List, arrow_type: pa.DataType, ta_type: dt.DType
+    ):
+        s = pa.array(pydata, type=arrow_type)
         t = ta.from_arrow(s, device=self.device)
-        self.assertEqual(t.dtype, dt.Float64(True))
-        for i, j in zip([i.as_py() for i in s], list(t)):
-            if math.isnan(i) and math.isnan(j):
+        self.assertEqual(t.dtype, ta_type)
+        for pa_val, ta_val in zip([i.as_py() for i in s], list(t)):
+            if pa_val and math.isnan(pa_val) and ta_val and math.isnan(ta_val):
                 pass
             else:
-                self.assertEqual(i, j)
+                self.assertEqual(pa_val, ta_val)
 
-        s = pa.array([1.0, None, 3])
-        t = ta.from_arrow(s, device=self.device)
-        self.assertEqual(t.dtype, dt.Float64(True))
-        self.assertEqual([i.as_py() for i in s], list(t))
-
-        s = pa.array([1, 2, 3], type=pa.int16())
-        t = ta.from_arrow(s, dtype=dt.Int16(False), device=self.device)
-        self.assertEqual(t.dtype, dt.Int16(False))
-        self.assertEqual(
-            [i.as_py() for i in s],
-            list(t),
-        )
-
-        s = pa.array([True, False, True])
+    def base_test_arrow_array(self):
+        s = pa.array([True, True, False, None, False])
         t = ta.from_arrow(s, device=self.device)
         self.assertEqual(t.dtype, dt.Boolean(True))
-        self.assertEqual(
-            [i.as_py() for i in s], list(ta.from_arrow(s, device=self.device))
-        )
-
-        s = pa.array(["a", "b", "c", "d", "e", "f", "g"])
-        t = ta.from_arrow(s, device=self.device)
-        self.assertEqual(t.dtype, dt.String(True))
         self.assertEqual([i.as_py() for i in s], list(t))
 
-        # TODO Test that nested types and other unsupported types are error-ed out
+        self.assertEqual(pa.utf8(), pa.string())
+        self.assertEqual(pa.large_utf8(), pa.large_string())
+
+        pydata_int = [1, 2, 3, None, 5, None]
+        pydata_float = [1.0, math.nan, 3, None, 5.0, None]
+        pydata_string = ["a", "b", None, "d", None, "f", "g"]
+        for (arrow_type, ta_type) in TestArrowInterop.supported_types:
+            if pa.types.is_integer(arrow_type):
+                self._test_construction_numeric(pydata_int, arrow_type, ta_type)
+            elif pa.types.is_floating(arrow_type):
+                self._test_construction_numeric(pydata_float, arrow_type, ta_type)
+            elif pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
+                s = pa.array(pydata_string, type=arrow_type)
+                t = ta.from_arrow(s, device=self.device)
+                self.assertEqual(t.dtype, ta_type)
+                self.assertEqual([i.as_py() for i in s], list(t))
 
     def base_test_ownership_transferred(self):
         pydata = [1, 2, 3]
@@ -79,3 +109,21 @@ class TestArrowInterop(unittest.TestCase):
 
         del t
         self.assertEqual(pa.total_allocated_bytes(), initial_memory)
+
+    def base_test_unsupported_types(self):
+        for arrow_type in TestArrowInterop.unsupported_types:
+            s = pa.array([], type=arrow_type)
+            with self.assertRaises(RuntimeError) as ex:
+                t = ta.from_arrow(s, device=self.device)
+            self.assertTrue(
+                f"Unsupported Arrow type: {str(arrow_type)}" in str(ex.exception)
+            )
+
+        union_array = pa.UnionArray.from_sparse(
+            types=pa.array([0], type=pa.int8()), children=[pa.array([1])]
+        )
+        with self.assertRaises(RuntimeError) as ex:
+            t = ta.from_arrow(union_array, device=self.device)
+        self.assertTrue(
+            f"Unsupported Arrow type: {str(union_array.type)}" in str(ex.exception)
+        )

--- a/torcharrow/test/test_arrow_interop.py
+++ b/torcharrow/test/test_arrow_interop.py
@@ -1,0 +1,81 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import math
+import unittest
+
+import pyarrow as pa
+import torcharrow as ta
+import torcharrow.dtypes as dt
+
+
+class TestArrowInterop(unittest.TestCase):
+    def base_test_arrow_array(self):
+        s = pa.array([1, 2, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Int64(True))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        s = pa.array([1.0, math.nan, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Float64(True))
+        for i, j in zip([i.as_py() for i in s], list(t)):
+            if math.isnan(i) and math.isnan(j):
+                pass
+            else:
+                self.assertEqual(i, j)
+
+        s = pa.array([1.0, None, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Float64(True))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        s = pa.array([1, 2, 3], type=pa.int16())
+        t = ta.from_arrow(s, dtype=dt.Int16(False), device=self.device)
+        self.assertEqual(t.dtype, dt.Int16(False))
+        self.assertEqual(
+            [i.as_py() for i in s],
+            list(t),
+        )
+
+        s = pa.array([True, False, True])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Boolean(True))
+        self.assertEqual(
+            [i.as_py() for i in s], list(ta.from_arrow(s, device=self.device))
+        )
+
+        s = pa.array(["a", "b", "c", "d", "e", "f", "g"])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.String(True))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        # TODO Test that nested types and other unsupported types are error-ed out
+
+    def base_test_ownership_transferred(self):
+        pydata = [1, 2, 3]
+        s = pa.array(pydata)
+        t = ta.from_arrow(s)
+        del s
+        # Check that the data are still around
+        self.assertEqual(pydata, list(t))
+
+    def base_test_memory_reclaimed(self):
+        initial_memory = pa.total_allocated_bytes()
+
+        s = pa.array([1, 2, 3])
+        memory_checkpoint_1 = pa.total_allocated_bytes()
+        self.assertGreater(memory_checkpoint_1, initial_memory)
+
+        # Extra memory are allocated when exporting Arrow data, for the new
+        # ArrowArray and ArrowSchema objects and the private_data inside the
+        # objects
+        t = ta.from_arrow(s)
+        memory_checkpoint_2 = pa.total_allocated_bytes()
+        self.assertGreater(memory_checkpoint_2, memory_checkpoint_1)
+
+        # Deleting the pyarrow array should not release any memory since the
+        # buffers are now owned by the TA column
+        del s
+        self.assertEqual(pa.total_allocated_bytes(), memory_checkpoint_2)
+
+        del t
+        self.assertEqual(pa.total_allocated_bytes(), initial_memory)

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -20,6 +20,9 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_unsupported_types(self):
         return self.base_test_unsupported_types()
 
+    def test_nullability(self):
+        return self.base_test_nullability()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -17,6 +17,9 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_memory_reclaimed(self):
         return self.base_test_memory_reclaimed()
 
+    def test_unsupported_types(self):
+        return self.base_test_unsupported_types()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+from .test_arrow_interop import TestArrowInterop
+
+
+class TestArrowInteropCpu(TestArrowInterop):
+    def setUp(self):
+        self.device = "cpu"
+
+    def test_arrow_array(self):
+        return self.base_test_arrow_array()
+
+    def test_ownership_transferred(self):
+        return self.base_test_ownership_transferred()
+
+    def test_memory_reclaimed(self):
+        return self.base_test_memory_reclaimed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torcharrow/test/test_interop.py
+++ b/torcharrow/test/test_interop.py
@@ -6,51 +6,9 @@ import pyarrow as pa
 import torcharrow as ta
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as tap
-from torcharrow.scope import Scope
 
 
 class TestInterop(unittest.TestCase):
-    def base_test_arrow_array(self):
-        s = pa.array([1, 2, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual([i.as_py() for i in s], list(t))
-
-        s = pa.array([1.0, np.nan, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Float64(False))
-        # can't compare nan, so
-
-        for i, j in zip([i.as_py() for i in s], list(t)):
-            if np.isnan(i) and np.isnan(j):
-                pass
-            else:
-                self.assertEqual(i, j)
-
-        s = pa.array([1.0, None, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Float64(True))
-        self.assertEqual([i.as_py() for i in s], list(t))
-
-        s = pa.array([1, 2, 3], type=pa.uint32())
-        self.assertEqual(
-            [i.as_py() for i in s], list(self.ts.from_arrow(s, dt.Int16(False)))
-        )
-
-        s = pa.array([1, 2, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Int64(False))
-        self.assertEqual([i.as_py() for i in s], list(self.ts.from_arrow(s)))
-
-        s = pa.array([True, False, True])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Boolean(False))
-        self.assertEqual([i.as_py() for i in s], list(self.ts.from_arrow(s)))
-
-        s = pa.array(["a", "b", "c", "d", "e", "f", "g"])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.String(False))
-        self.assertEqual([i.as_py() for i in s], list(t))
-
     def base_test_to_pytorch(self):
         import torch
 

--- a/torcharrow/test/test_interop_cpu.py
+++ b/torcharrow/test/test_interop_cpu.py
@@ -14,10 +14,6 @@ class TestInteropCpu(TestInterop):
     def setUp(self):
         self.device = "cpu"
 
-    def test_arrow_array(self):
-        # TODO: support arrow interop in CPU backend
-        pass
-
     @unittest.skipUnless(tap.available, "Requires PyTorch")
     def test_to_pytorch(self):
         return self.base_test_to_pytorch()

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -49,6 +49,34 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
             True,
         )
 
+    @staticmethod
+    def _fromarrow(device: str, array, dtype: dt.DType):
+        import pyarrow as pa
+        from pyarrow.cffi import ffi
+
+        assert isinstance(array, pa.Array)
+
+        c_schema = ffi.new("struct ArrowSchema*")
+        ptr_schema = int(ffi.cast("uintptr_t", c_schema))
+        c_array = ffi.new("struct ArrowArray*")
+        ptr_array = int(ffi.cast("uintptr_t", c_array))
+        array._export_to_c(ptr_array, ptr_schema)
+
+        velox_column = velox._import_from_arrow(
+            get_velox_type(dtype), ptr_array, ptr_schema
+        )
+
+        # Make sure the ownership of c_schema and c_array have been transferred
+        # to velox_column
+        assert c_schema.release == ffi.NULL and c_array.release == ffi.NULL
+
+        return ColumnFromVelox.from_velox(
+            device,
+            dtype,
+            velox_column,
+            True,
+        )
+
     def _append_null(self):
         if self._finialized:
             raise AttributeError("It is already finialized.")
@@ -879,3 +907,6 @@ _primitive_types: List[dt.DType] = [
 for t in _primitive_types:
     Dispatcher.register((t.typecode + "_empty", "cpu"), NumericalColumnCpu._empty)
     Dispatcher.register((t.typecode + "_fromlist", "cpu"), NumericalColumnCpu._fromlist)
+    Dispatcher.register(
+        (t.typecode + "_fromarrow", "cpu"), NumericalColumnCpu._fromarrow
+    )

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -80,6 +80,16 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
             True,
         )
 
+    # TODO Add native kernel support
+    @staticmethod
+    def _fromarrow(device: str, array, dtype: dt.DType):
+        import pyarrow as pa
+
+        assert isinstance(array, pa.Array)
+
+        pydata = [i.as_py() for i in array]
+        return StringColumnCpu._fromlist(device, pydata, dtype)
+
     def _append_null(self):
         if self._finialized:
             raise AttributeError("It is already finialized.")
@@ -342,6 +352,9 @@ Dispatcher.register((dt.String.typecode + "_empty", "cpu"), StringColumnCpu._emp
 Dispatcher.register((dt.String.typecode + "_full", "cpu"), StringColumnCpu._full)
 Dispatcher.register(
     (dt.String.typecode + "_fromlist", "cpu"), StringColumnCpu._fromlist
+)
+Dispatcher.register(
+    (dt.String.typecode + "_fromarrow", "cpu"), StringColumnCpu._fromarrow
 )
 
 


### PR DESCRIPTION
Summary:
Added argument `nullable` to `from_arrow` and get back the behavior of defaulting `nullable` to null_count > 0.

Removed `dtype` argument since type casting alongside with zero-copy data passing between Arrow and TA/Velox is not supported at the moment. We can always infer TA dtype from the Arrow type.

Differential Revision: D32662634

