### PR TITLE
Initial support for list.vmap

### DIFF
--- a/csrc/velox/column.h
+++ b/csrc/velox/column.h
@@ -682,6 +682,8 @@ class ArrayColumn : public BaseColumn {
       velox::vector_size_t length) {
     return std::make_unique<ArrayColumn>(*this, offset, length);
   }
+
+  std::unique_ptr<ArrayColumn> withElements(const BaseColumn& newElements);
 };
 
 class MapColumn : public BaseColumn {

--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -577,9 +577,10 @@ void declareArrayType(py::module& m) {
       .def("append_null", &ArrayColumn::appendNull)
       .def("__getitem__", &ArrayColumn::valueAt)
       .def("elements", &ArrayColumn::elements)
-      .def("slice", &ArrayColumn::slice);
+      .def("slice", &ArrayColumn::slice)
+      .def("withElements", &ArrayColumn::withElements);
 
-  using I = typename velox::TypeTraits<velox::TypeKind::ARRAY>::ImplType;
+      using I = typename velox::TypeTraits<velox::TypeKind::ARRAY>::ImplType;
   py::class_<I, velox::Type, std::shared_ptr<I>>(
       m,
       "VeloxArrayType",

--- a/torcharrow/test/transformation/test_list.py
+++ b/torcharrow/test/transformation/test_list.py
@@ -1,0 +1,57 @@
+import unittest
+
+import torcharrow as ta
+import torcharrow.dtypes as dt
+
+# TODO: add/migrate more list tests
+class _TestListBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Prepare input data as CPU dataframe
+        cls.base_df = ta.DataFrame(
+            {
+                "int_list": [[1, 2, None, 3], [4, None, 5], None],
+                "str_list": [["a,b,c", "d,e"], [None, "g,h"], None],
+                "struct_list": ta.Column(
+                    [[(1, "a"), (2, "b")], [(3, "c")], None],
+                    dtype=dt.List(
+                        dt.Struct([dt.Field("f1", dt.int64), dt.Field("f2", dt.string)])
+                    ),
+                ),
+            }
+        )
+
+        cls.setUpTestCaseData()
+
+    @classmethod
+    def setUpTestCaseData(cls):
+        # Override in subclass
+        raise unittest.SkipTest("abstract base test")
+
+    def test_vmap(self):
+        df = type(self).df
+
+        self.assertEqual(
+            list(df["int_list"].list.vmap(lambda col: col + 7)),
+            [[8, 9, None, 10], [11, None, 12], None],
+        )
+
+        self.assertEqual(
+            list(df["str_list"].list.vmap(lambda col: col.str.split(","))),
+            [[["a", "b", "c"], ["d", "e"]], [None, ["g", "h"]], None],
+        )
+
+        self.assertEqual(
+            list(df["struct_list"].list.vmap(lambda df: df["f2"] + "_suffix")),
+            [["a_suffix", "b_suffix"], ["c_suffix"], None],
+        )
+
+
+class TestNumericOpsCpu(_TestListBase):
+    @classmethod
+    def setUpTestCaseData(cls):
+        cls.df = cls.base_df.copy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import array as ar
 import warnings
-from typing import List
+from typing import List, Callable
 
 import numpy as np
 import torcharrow as ta
@@ -11,6 +11,7 @@ import torcharrow.pytorch as pytorch
 from tabulate import tabulate
 from torcharrow.scope import Scope
 from torcharrow.dispatcher import Dispatcher
+from torcharrow.icolumn import IColumn
 from torcharrow.ilist_column import IListColumn, IListMethods
 
 from .column import ColumnFromVelox
@@ -191,6 +192,20 @@ class ListMethodsCpu(IListMethods):
 
     def __init__(self, parent: ListColumnCpu):
         super().__init__(parent)
+
+    def vmap(self, fun: Callable[[IColumn], IColumn]):
+        elements = ColumnFromVelox._from_velox(
+            self._parent.device,
+            self._parent._dtype.item_dtype,
+            self._parent._data.elements(),
+            True,
+        )
+        new_elements = fun(elements)
+
+        new_data = self._parent._data.withElements(new_elements._data)
+        return ColumnFromVelox._from_velox(
+            self._parent.device, new_data.dtype(), new_data, True
+        )
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
Data transformation often needs to apply the same operation to each element in the list. A simple example would be to add 1 to each element in a `list[int]`, or extract a field in each element to a `list[struct]`.

This is somewhat similar to JAX's vectorizing map: https://jax.readthedocs.io/en/latest/notebooks/quickstart.html#auto-vectorization-with-vmap : lifts an expression acting on a single example into a thing working on a batch (i.e. `IColumn`).

Example:
```python
>>> import torcharrow as ta
>>> a = ta.Column([[1, 2, None, 3], [4, None, 5]])

>>> a
0  [1, 2, None, 3]
1  [4, None, 5]
dtype: List(Int64(nullable=True)), length: 2, null_count: 0

>>> a.list.vmap(lambda col: col + 1)
0  [2, 3, None, 4]
1  [5, None, 6]
dtype: List(Int64(nullable=True), nullable=True), length: 2, null_count: 0

>>> import torcharrow.dtypes as dt
>>> b = ta.Column([[(1, "a"), (2, "b")], [(3, "c")]],
    dtype=dt.List(
        dt.Struct([dt.Field("f1", dt.int64), dt.Field("f2", dt.string)])
    ))

>>> b
0  [(1, 'a'), (2, 'b')]
1  [(3, 'c')]
dtype: List(Struct([Field('f1', int64), Field('f2', string)])), length: 2, null_count: 0

>>> b.list.vmap(lambda df: df["f2"])
0  ['a', 'b']
1  ['c']
dtype: List(String(nullable=True), nullable=True), length: 2, null_count: 0
```

Some thoughts:

1. Do we still need these "scalar" form? e.g .`IListColumn.list.map`. They can be expressed by normal `IColumn.map`
2. Note in JAX `vmap` is a high-order function, for example it promotes matrix-vector products into matrix-matrix products. While in TorchArrow `list.vmap` already expects a Python lambda that works on (flattened) column and applies it.
3. Shall we also support `list.vfilter`?
4. We still need to support Velox lambda expressions, for things like [`array_sort`]( https://prestodb.io/docs/current/functions/array.html#id3) . But this `vmap`-style approach can be used to support [`transform`](https://prestodb.io/docs/current/functions/array.html#transform), [`filter`](https://prestodb.io/docs/current/functions/array.html#filter), [`transform_keys`](https://prestodb.io/docs/current/functions/map.html#transform_keys) and [`transform_values`](https://prestodb.io/docs/current/functions/map.html#transform_values).

Differential Revision: D32748918

