### PR TITLE
Move cummin/cummax/cumprod as "private API"

### DIFF
--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -1349,21 +1349,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         self._prototype_support_warning("any")
         return any(self._data_iter())
 
-    # cummin/cummax/cumsum/cumprod
-    @trace
-    @expression
-    def cummin(self):
-        """Return cumulative minimum of the data."""
-        self._prototype_support_warning("cummin")
-        return self._accumulate(min)
-
-    @trace
-    @expression
-    def cummax(self):
-        """Return cumulative maximum of the data."""
-        self._prototype_support_warning("cummax")
-        return self._accumulate(max)
-
+    # cumsum
     @trace
     @expression
     def cumsum(self):
@@ -1371,14 +1357,6 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         self._prototype_support_warning("cumsum")
         self._check(dt.is_numerical, "cumsum")
         return self._accumulate(operator.add)
-
-    @trace
-    @expression
-    def cumprod(self):
-        """Return cumulative product of the data."""
-        self._prototype_support_warning("cumprod")
-        self._check(dt.is_numerical, "cumprod")
-        return self._accumulate(operator.mul)
 
     # describe ----------------------------------------------------------------
     @trace
@@ -1798,3 +1776,26 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             return len(set(self))
         else:
             return len(set(i for i in self if i is not None))
+
+    # cummin/cummax/cumprod
+    @trace
+    @expression
+    def _cummin(self):
+        """Return cumulative minimum of the data."""
+        self._prototype_support_warning("_cummin")
+        return self._accumulate(min)
+
+    @trace
+    @expression
+    def _cummax(self):
+        """Return cumulative maximum of the data."""
+        self._prototype_support_warning("_cummax")
+        return self._accumulate(max)
+
+    @trace
+    @expression
+    def _cumprod(self):
+        """Return cumulative product of the data."""
+        self._prototype_support_warning("_cumprod")
+        self._check(dt.is_numerical, "_cumprod")
+        return self._accumulate(operator.mul)

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -586,11 +586,11 @@ class TestDataFrame(unittest.TestCase):
         # self.assertEqual(C.median()["a"], statistics.median(c))
 
         self.assertEqual(
-            list(C.cummin()),
+            list(C._cummin()),
             [(i,) for i in [min(c[:i]) for i in range(1, len(c) + 1)] + [None]],
         )
         self.assertEqual(
-            list(C.cummax()),
+            list(C._cummax()),
             [(i,) for i in [max(c[:i]) for i in range(1, len(c) + 1)] + [None]],
         )
         self.assertEqual(
@@ -598,7 +598,7 @@ class TestDataFrame(unittest.TestCase):
             [(i,) for i in [sum(c[:i]) for i in range(1, len(c) + 1)] + [None]],
         )
         self.assertEqual(
-            list(C.cumprod()),
+            list(C._cumprod()),
             [
                 (i,)
                 for i in [

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -408,16 +408,16 @@ class TestNumericalColumn(unittest.TestCase):
         self.assertEqual(C.median(), statistics.median(c))
 
         self.assertEqual(
-            list(C.cummin()), [min(c[:i]) for i in range(1, len(c) + 1)] + [None]
+            list(C._cummin()), [min(c[:i]) for i in range(1, len(c) + 1)] + [None]
         )
         self.assertEqual(
-            list(C.cummax()), [max(c[:i]) for i in range(1, len(c) + 1)] + [None]
+            list(C._cummax()), [max(c[:i]) for i in range(1, len(c) + 1)] + [None]
         )
         self.assertEqual(
             list(C.cumsum()), [sum(c[:i]) for i in range(1, len(c) + 1)] + [None]
         )
         self.assertEqual(
-            list(C.cumprod()),
+            list(C._cumprod()),
             [functools.reduce(operator.mul, c[:i], 1) for i in range(1, len(c) + 1)]
             + [None],
         )

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -1417,15 +1417,15 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     @trace
     @expression
-    def cummin(self):
+    def _cummin(self):
         """Return cumulative minimum of the data."""
-        return self._lift(lambda c: c.cummin)
+        return self._lift(lambda c: c._cummin)
 
     @trace
     @expression
-    def cummax(self):
+    def _cummax(self):
         """Return cumulative maximum of the data."""
-        return self._lift(lambda c: c.cummax)
+        return self._lift(lambda c: c._cummax)
 
     @trace
     @expression
@@ -1435,9 +1435,9 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     @trace
     @expression
-    def cumprod(self):
+    def _cumprod(self):
         """Return cumulative product of the data."""
-        return self._lift(lambda c: c.cumprod)
+        return self._lift(lambda c: c._cumprod)
 
     @trace
     @expression

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -779,17 +779,17 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
 
     @trace
     @expression
-    def cummin(self):
+    def _cummin(self):
         """Return cumulative minimum of the data."""
-        self._prototype_support_warning("cummin")
+        self._prototype_support_warning("_cummin")
 
         return self._accumulate_column(min, skipna=True, initial=None)
 
     @trace
     @expression
-    def cummax(self):
+    def _cummax(self):
         """Return cumulative maximum of the data."""
-        self._prototype_support_warning("cummax")
+        self._prototype_support_warning("_cummax")
 
         return self._accumulate_column(max, skipna=True, initial=None)
 
@@ -803,9 +803,9 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
 
     @trace
     @expression
-    def cumprod(self):
+    def _cumprod(self):
         """Return cumulative product of the data."""
-        self._prototype_support_warning("cumprod")
+        self._prototype_support_warning("_cumprod")
 
         return self._accumulate_column(operator.mul, skipna=True, initial=None)
 


### PR DESCRIPTION
Summary: These methods don't yet have an efficient implementations, and not yet supported by arrow compute either.

Reviewed By: wenleix, OswinC

Differential Revision: D32764883

