### PR TITLE
re-organize presto function registration (#589)

### DIFF
--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -12,9 +12,8 @@
 #include "column.h"
 #include "functions/functions.h" // @manual=//pytorch/torcharrow/csrc/velox/functions:torcharrow_functions
 #include "velox/buffer/StringViewBufferHolder.h"
-#include "velox/functions/prestosql/SimpleFunctions.h"
-#include "velox/functions/prestosql/VectorFunctions.h"
 #include "velox/vector/TypeAliases.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
@@ -750,8 +749,7 @@ PYBIND11_MODULE(_torcharrow, m) {
 
   // Register Velox UDFs
   // TODO: we may only need to register UDFs that TorchArrow required?
-  velox::functions::registerFunctions();
-  velox::functions::registerVectorFunctions();
+  velox::functions::prestosql::registerAllFunctions();
 
   functions::registerTorchArrowFunctions();
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/presto_cpp/pull/589

- Split function registrations to semantic type-based category:
Deprecate registerVectorFunctions() and registerSimpleFunctions()
and instead introduce registerStringFunctions(), registerMapFunctions()...etc.
also registerAllFunctions()

- This split reduces the compile time and the recompile-frequency by
 distributing the instantiations of the simple functions across multiple compilation units.

- Registration files moved to their own directory.

- Two targets: velox_functions_prestosql_impl, and velox_functions_prestosql.

- Also i noticed many of velox users used to include simpleFunctions.h and VectorFunctions.h
with out needing them. (they register their own functions) .I removed those
a bunch of dependencies to velox_functions_prestosql are removed accordingly.

{F680655057}

Pull Request resolved: https://github.com/facebookincubator/velox/pull/618

Test Plan:
compile after touch stringFunctions.h
before:

{F680580371}

after:

{F680580659}

Reviewed By: mbasmanova

Differential Revision: D32444495

Pulled By: laithsakka

