### PR TITLE
Add from_arrow support for primitive type Arrays (#82)

### DIFF
--- a/csrc/velox/CMakeLists.txt
+++ b/csrc/velox/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(_torcharrow PRIVATE
   velox_core
   velox_functions_prestosql
   velox_function_registry
+  velox_arrow_bridge
   torcharrow_udfs)
 
 #target_compile_definitions(_torcharrow PRIVATE)

--- a/csrc/velox/column.h
+++ b/csrc/velox/column.h
@@ -7,14 +7,15 @@
 #include <unordered_map>
 #include "vector.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/core/QueryCtx.h"
-#include "velox/common/base/Exceptions.h"
 #include "velox/expression/Expr.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
+#include "velox/vector/arrow/Bridge.h"
 
 // TODO: Move uses of static variables into .cpp. Static variables are local to
 // the compilation units so every file that includes this header will have its
@@ -601,8 +602,8 @@ class SimpleColumn : public BaseColumn {
 
     const static auto inputRowType =
         velox::ROW({"c0"}, {velox::CppToType<T>::create()});
-    const static auto op = OperatorHandle::fromGenericUDF(
-        inputRowType, "torcharrow_isinteger");
+    const static auto op =
+        OperatorHandle::fromGenericUDF(inputRowType, "torcharrow_isinteger");
     return op->call({_delegate});
   }
 

--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -12,8 +12,10 @@
 #include "column.h"
 #include "functions/functions.h" // @manual=//pytorch/torcharrow/csrc/velox/functions:torcharrow_functions
 #include "velox/buffer/StringViewBufferHolder.h"
+#include "velox/type/Type.h"
 #include "velox/vector/TypeAliases.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/arrow/Bridge.h"
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
@@ -136,6 +138,34 @@ py::class_<SimpleColumn<T>, BaseColumn> declareSimpleType(
          py::list data) -> std::unique_ptr<SimpleColumn<T>> {
         return std::make_unique<SimpleColumn<T>>(flatVectorFromPyList<T>(data));
       });
+
+  // Import Arrow data
+  //
+  // VARCHAR is not supported at the moment
+  // https://github.com/facebookincubator/velox/blob/f420d3115eeb8ad782aa9979f47be03671ed02f4/velox/vector/arrow/Bridge.cpp#L128
+  if constexpr (
+      kind == velox::TypeKind::BOOLEAN || kind == velox::TypeKind::TINYINT ||
+      kind == velox::TypeKind::SMALLINT || kind == velox::TypeKind::INTEGER ||
+      kind == velox::TypeKind::BIGINT || kind == velox::TypeKind::REAL ||
+      kind == velox::TypeKind::DOUBLE) {
+    m.def(
+        "_import_from_arrow",
+        [](std::shared_ptr<I> type, uintptr_t ptrArray, uintptr_t ptrSchema) {
+          auto column =
+              std::make_unique<SimpleColumn<T>>(velox::importFromArrowAsOwner(
+                  *reinterpret_cast<ArrowSchema*>(ptrSchema),
+                  *reinterpret_cast<ArrowArray*>(ptrArray),
+                  TorchArrowGlobalStatic::rootMemoryPool()));
+
+          VELOX_CHECK(
+              column->type()->kind() == kind,
+              "Expected TypeKind is {} but Velox created {}",
+              velox::TypeTraits<kind>::name,
+              column->type()->kindName());
+
+          return column;
+        });
+  }
 
   return result;
 };

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ setup(
     license="BSD",
     install_requires=[
         "arrow",
+        "cffi",
         "numpy==1.21.4",
         "pandas",
         "typing",

--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -21,7 +21,7 @@ from .idataframe import *
 from .velox_rt import *
 
 from . import pytorch
-from .interop import from_pylist
+from .interop import from_pylist, from_arrow
 
 try:
     from .version import __version__  # noqa: F401

--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -1,6 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import pandas as pd  # type: ignore
-import pyarrow as pa  # type: ignore
 import torcharrow.dtypes as dt
 from torcharrow import Scope
 
@@ -37,6 +36,7 @@ def from_pylist(data, dtype=None, device=""):
     """
     Convert Python list of scalars or containers to a TorchArrow Column/DataFrame.
     """
+    # TODO(https://github.com/facebookresearch/torcharrow/issues/80) Infer dtype
     device = device or Scope.default.device
 
     return Scope.default._FromPyList(data, dtype, device)

--- a/torcharrow/test/test_arrow_interop.py
+++ b/torcharrow/test/test_arrow_interop.py
@@ -1,0 +1,81 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import math
+import unittest
+
+import pyarrow as pa
+import torcharrow as ta
+import torcharrow.dtypes as dt
+
+
+class TestArrowInterop(unittest.TestCase):
+    def base_test_arrow_array(self):
+        s = pa.array([1, 2, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Int64(False))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        s = pa.array([1.0, math.nan, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Float64(False))
+        for i, j in zip([i.as_py() for i in s], list(t)):
+            if math.isnan(i) and math.isnan(j):
+                pass
+            else:
+                self.assertEqual(i, j)
+
+        s = pa.array([1.0, None, 3])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Float64(True))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        s = pa.array([1, 2, 3], type=pa.int16())
+        t = ta.from_arrow(s, dtype=dt.Int16(False), device=self.device)
+        self.assertEqual(t.dtype, dt.Int16(False))
+        self.assertEqual(
+            [i.as_py() for i in s],
+            list(t),
+        )
+
+        s = pa.array([True, False, True])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.Boolean(False))
+        self.assertEqual(
+            [i.as_py() for i in s], list(ta.from_arrow(s, device=self.device))
+        )
+
+        s = pa.array(["a", "b", "c", "d", "e", "f", "g"])
+        t = ta.from_arrow(s, device=self.device)
+        self.assertEqual(t.dtype, dt.String(False))
+        self.assertEqual([i.as_py() for i in s], list(t))
+
+        # TODO Test that nested types and other unsupported types are error-ed out
+
+    def base_test_ownership_transferred(self):
+        pydata = [1, 2, 3]
+        s = pa.array(pydata)
+        t = ta.from_arrow(s)
+        del s
+        # Check that the data are still around
+        self.assertEqual(pydata, list(t))
+
+    def base_test_memory_reclaimed(self):
+        initial_memory = pa.total_allocated_bytes()
+
+        s = pa.array([1, 2, 3])
+        memory_checkpoint_1 = pa.total_allocated_bytes()
+        self.assertGreater(memory_checkpoint_1, initial_memory)
+
+        # Extra memory are allocated when exporting Arrow data, for the new
+        # ArrowArray and ArrowSchema objects and the private_data inside the
+        # objects
+        t = ta.from_arrow(s)
+        memory_checkpoint_2 = pa.total_allocated_bytes()
+        self.assertGreater(memory_checkpoint_2, memory_checkpoint_1)
+
+        # Deleting the pyarrow array should not release any memory since the
+        # buffers are now owned by the TA column
+        del s
+        self.assertEqual(pa.total_allocated_bytes(), memory_checkpoint_2)
+
+        del t
+        self.assertEqual(pa.total_allocated_bytes(), initial_memory)

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+from .test_arrow_interop import TestArrowInterop
+
+
+class TestArrowInteropCpu(TestArrowInterop):
+    def setUp(self):
+        self.device = "cpu"
+
+    def test_arrow_array(self):
+        return self.base_test_arrow_array()
+
+    def test_ownership_transferred(self):
+        return self.base_test_ownership_transferred()
+
+    def test_memory_reclaimed(self):
+        return self.base_test_memory_reclaimed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torcharrow/test/test_interop.py
+++ b/torcharrow/test/test_interop.py
@@ -6,51 +6,9 @@ import pyarrow as pa
 import torcharrow as ta
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as tap
-from torcharrow.scope import Scope
 
 
 class TestInterop(unittest.TestCase):
-    def base_test_arrow_array(self):
-        s = pa.array([1, 2, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual([i.as_py() for i in s], list(t))
-
-        s = pa.array([1.0, np.nan, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Float64(False))
-        # can't compare nan, so
-
-        for i, j in zip([i.as_py() for i in s], list(t)):
-            if np.isnan(i) and np.isnan(j):
-                pass
-            else:
-                self.assertEqual(i, j)
-
-        s = pa.array([1.0, None, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Float64(True))
-        self.assertEqual([i.as_py() for i in s], list(t))
-
-        s = pa.array([1, 2, 3], type=pa.uint32())
-        self.assertEqual(
-            [i.as_py() for i in s], list(self.ts.from_arrow(s, dt.Int16(False)))
-        )
-
-        s = pa.array([1, 2, 3])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Int64(False))
-        self.assertEqual([i.as_py() for i in s], list(self.ts.from_arrow(s)))
-
-        s = pa.array([True, False, True])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.Boolean(False))
-        self.assertEqual([i.as_py() for i in s], list(self.ts.from_arrow(s)))
-
-        s = pa.array(["a", "b", "c", "d", "e", "f", "g"])
-        t = self.ts.from_arrow(s)
-        self.assertEqual(t.dtype, dt.String(False))
-        self.assertEqual([i.as_py() for i in s], list(t))
-
     def base_test_to_pytorch(self):
         import torch
 

--- a/torcharrow/test/test_interop_cpu.py
+++ b/torcharrow/test/test_interop_cpu.py
@@ -14,10 +14,6 @@ class TestInteropCpu(TestInterop):
     def setUp(self):
         self.device = "cpu"
 
-    def test_arrow_array(self):
-        # TODO: support arrow interop in CPU backend
-        pass
-
     @unittest.skipUnless(tap.available, "Requires PyTorch")
     def test_to_pytorch(self):
         return self.base_test_to_pytorch()

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -80,6 +80,16 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
             True,
         )
 
+    # TODO Add native kernel support
+    @staticmethod
+    def _fromarrow(device: str, array, dtype: dt.DType):
+        import pyarrow as pa
+
+        assert isinstance(array, pa.Array)
+
+        pydata = [i.as_py() for i in array]
+        return StringColumnCpu._fromlist(device, pydata, dtype)
+
     def _append_null(self):
         if self._finialized:
             raise AttributeError("It is already finialized.")
@@ -342,6 +352,9 @@ Dispatcher.register((dt.String.typecode + "_empty", "cpu"), StringColumnCpu._emp
 Dispatcher.register((dt.String.typecode + "_full", "cpu"), StringColumnCpu._full)
 Dispatcher.register(
     (dt.String.typecode + "_fromlist", "cpu"), StringColumnCpu._fromlist
+)
+Dispatcher.register(
+    (dt.String.typecode + "_fromarrow", "cpu"), StringColumnCpu._fromarrow
 )
 
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/torcharrow/pull/82

Add _fromarrow support for primitive types, including boolean, signed integer types, floating types, and string. The support for numerical types are true zero-copy interop, by integrating Velox's Arrow interop support.

The support for string Arrow interop is implemented by copying the data in the Arrow buffer into a new Velox column so is not zero-copy. This will need to be pushed down to Velox layer to achieve true zero-copy interop but adding it now since it will enable many use cases.

Reference for the cffi technique used to pass C++ pointers between Python and C++: https://github.com/facebookresearch/torcharrow/wiki/Arrow-Velox-zero-copy-conversion

Reviewed By: wenleix

Differential Revision: D32290990

