### PR TITLE
Clean up imports in __init__.py

### DIFF
--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -1,32 +1,26 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-# For relative imports to work in Python 3.6
-from .expression import *  # dependencies: None
-from .trace import *  # dependencies: expression
-
-# don't include
-# from .dtypes import *
-# since dtypes define Tuple and List which confuse mypy
-
-from .scope import *  # dependencies: column_factory, dtypes
-
-# following needs scope*
-from .icolumn import Column, concat, if_else  # noqa
-from .inumerical_column import *
-from .istring_column import *
-from .ilist_column import *
-from .imap_column import *
-from .idataframe import *
-
-from .velox_rt import *
-
-from . import pytorch
-from .interop import from_pylist, from_arrow
+from . import pytorch  # noqa
+from . import velox_rt  # noqa
+from .icolumn import IColumn, Column, concat, if_else  # noqa
+from .idataframe import IDataFrame, DataFrame, me  # noqa
+from .interop import from_pylist, from_arrow  # noqa
 
 try:
     from .version import __version__  # noqa: F401
 except ImportError:
     pass
+
+__all__ = [
+    "DataFrame",
+    "Column",
+    "concat",
+    "if_else",
+    "from_pylist",
+    "me",
+    "IDataFrame",
+    "IColumn",
+]
 
 # module level doc-string
 __doc__ = """

--- a/torcharrow/_interop.py
+++ b/torcharrow/_interop.py
@@ -9,7 +9,7 @@ import numpy.ma as ma  # type: ignore
 import pandas as pd  # type: ignore
 import pyarrow as pa  # type: ignore
 import torcharrow.dtypes as dt
-from torcharrow import Scope
+from torcharrow.scope import Scope
 
 
 def from_arrow_table(

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -1446,7 +1446,6 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     @trace
     def to_pylist(self):
         """Convert to plain Python container (list of scalars or containers)"""
-        self._prototype_support_warning("to_pylist")
         return list(self)
 
     @trace

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -921,42 +921,42 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     @trace
     @expression
     def __eq__(self, other):
-        """Vectorized a == b."""
+        """Return self == other."""
         self._prototype_support_warning("__eq__")
         return self._py_comparison_op(other, operator.eq)
 
     @trace
     @expression
     def __ne__(self, other):
-        """Vectorized a != b."""
+        """Return self != other."""
         self._prototype_support_warning("__ne__")
         return self._py_comparison_op(other, operator.ne)
 
     @trace
     @expression
     def __lt__(self, other):
-        """Vectorized a < b."""
+        """Return self < other."""
         self._prototype_support_warning("__lt__")
         return self._py_comparison_op(other, operator.lt)
 
     @trace
     @expression
     def __gt__(self, other):
-        """Vectorized a > b."""
+        """Return self > other."""
         self._prototype_support_warning("__gt__")
         return self._py_comparison_op(other, operator.gt)
 
     @trace
     @expression
     def __le__(self, other):
-        """Vectorized a < b."""
+        """Return self <= other."""
         self._prototype_support_warning("__le__")
         return self._py_comparison_op(other, operator.le)
 
     @trace
     @expression
     def __ge__(self, other):
-        """Vectorized a < b."""
+        """Return self >= other."""
         self._prototype_support_warning("__ge__")
         return self._py_comparison_op(other, operator.ge)
 

--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import pandas as pd  # type: ignore
 import torcharrow.dtypes as dt
-from torcharrow import Scope
+from torcharrow.scope import Scope
 
 from .dispatcher import Dispatcher
 

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -5,7 +5,8 @@ from typing import List, Optional, NamedTuple
 import numpy.testing
 import torcharrow as ta
 import torcharrow.dtypes as dt
-from torcharrow import IDataFrame, Scope, me
+from torcharrow import me
+from torcharrow.idataframe import IDataFrame
 
 # run python3 -m unittest outside this directory to run all tests
 

--- a/torcharrow/test/test_dataframe_cpu.py
+++ b/torcharrow/test/test_dataframe_cpu.py
@@ -1,10 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import functools
-import statistics
 import unittest
-
-import torcharrow.dtypes as dt
-from torcharrow import IDataFrame, Scope, me
 
 from .test_dataframe import TestDataFrame
 

--- a/torcharrow/test/test_expression.py
+++ b/torcharrow/test/test_expression.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from dataclasses import dataclass
 from typing import Any, Callable, List, Mapping, Optional, Sequence
 
-from torcharrow import Call, Expression, GetAttr, Var, eval_expression
+from torcharrow.expression import Call, Expression, GetAttr, Var, eval_expression
 
 # -----------------------------------------------------------------------------
 

--- a/torcharrow/test/test_functional_cpu.py
+++ b/torcharrow/test/test_functional_cpu.py
@@ -4,7 +4,6 @@ import unittest
 import torcharrow as ta
 import torcharrow._torcharrow
 import torcharrow.dtypes as dt
-from torcharrow import Scope, IStringColumn
 from torcharrow.functional import functional
 from torcharrow.velox_rt.functional import velox_functional
 

--- a/torcharrow/test/test_list_column.py
+++ b/torcharrow/test/test_list_column.py
@@ -4,7 +4,7 @@ import unittest
 
 import torcharrow as ta
 import torcharrow.dtypes as dt
-from torcharrow import IListColumn, INumericalColumn, Scope
+from torcharrow.ilist_column import IListColumn
 
 
 class TestListColumn(unittest.TestCase):

--- a/torcharrow/test/test_list_column_cpu.py
+++ b/torcharrow/test/test_list_column_cpu.py
@@ -1,9 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import operator
 import unittest
-
-import torcharrow.dtypes as dt
-from torcharrow import IListColumn, INumericalColumn, Scope
 
 from .test_list_column import TestListColumn
 

--- a/torcharrow/test/test_map_column.py
+++ b/torcharrow/test/test_map_column.py
@@ -1,11 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import operator
 import unittest
 
-import numpy.testing
 import torcharrow as ta
 import torcharrow.dtypes as dt
-from torcharrow import IMapColumn
+from torcharrow.imap_column import IMapColumn
 
 
 class TestMapColumn(unittest.TestCase):

--- a/torcharrow/test/test_map_column_cpu.py
+++ b/torcharrow/test/test_map_column_cpu.py
@@ -1,9 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import operator
 import unittest
-
-import torcharrow.dtypes as dt
-from torcharrow import Scope, IMapColumn
 
 from .test_map_column import TestMapColumn
 

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -7,8 +7,9 @@ import numpy as np
 import numpy.testing
 import torcharrow as ta
 import torcharrow.dtypes as dt
-from torcharrow import IColumn, INumericalColumn
-from torcharrow import Scope
+from torcharrow.icolumn import IColumn
+from torcharrow.inumerical_column import INumericalColumn
+from torcharrow.scope import Scope
 
 
 class TestNumericalColumn(unittest.TestCase):

--- a/torcharrow/test/test_numerical_column_cpu.py
+++ b/torcharrow/test/test_numerical_column_cpu.py
@@ -1,10 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-import torcharrow.dtypes as dt
-from torcharrow import INumericalColumn
-from torcharrow import Scope
-
 from .test_numerical_column import TestNumericalColumn
 
 

--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -3,7 +3,7 @@ import unittest
 
 import torcharrow as ta
 import torcharrow.dtypes as dt
-from torcharrow import IStringColumn
+from torcharrow.istring_column import IStringColumn
 
 
 class TestStringColumn(unittest.TestCase):

--- a/torcharrow/test/test_string_column_cpu.py
+++ b/torcharrow/test/test_string_column_cpu.py
@@ -1,9 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-import torcharrow.dtypes as dt
-from torcharrow import Scope, IStringColumn
-
 from .test_string_column import TestStringColumn
 
 

--- a/torcharrow/test/test_trace.py
+++ b/torcharrow/test/test_trace.py
@@ -4,7 +4,11 @@ import unittest
 
 import torcharrow as ta
 import torcharrow.dtypes as dt
-from torcharrow import IColumn, Scope, me, trace, GroupedDataFrame
+from torcharrow import me
+from torcharrow.icolumn import IColumn
+from torcharrow.scope import Scope
+from torcharrow.trace import trace
+from torcharrow.velox_rt.dataframe_cpu import GroupedDataFrame
 
 # -----------------------------------------------------------------------------
 # testdata

--- a/torcharrow/velox_rt/column.py
+++ b/torcharrow/velox_rt/column.py
@@ -2,7 +2,7 @@
 import typing as ty
 
 import torcharrow._torcharrow as velox
-from torcharrow import Scope
+from torcharrow.scope import Scope
 from torcharrow.dispatcher import Device
 from torcharrow.dtypes import DType
 from torcharrow.icolumn import IColumn

--- a/torcharrow/velox_rt/column.py
+++ b/torcharrow/velox_rt/column.py
@@ -13,7 +13,7 @@ class ColumnFromVelox:
     _finialized: bool
 
     @staticmethod
-    def from_velox(
+    def _from_velox(
         device: Device,
         dtype: DType,
         data: velox.BaseColumn,
@@ -26,11 +26,8 @@ class ColumnFromVelox:
 
     # Velox column returned from generic dispatch always assumes returned column is nullable
     # This help method allows to alter it based on context (e.g. methods in IStringMethods can have better inference)
-    #
-    # TODO: rename this as _with_null as alternating nullability is dangerous.
-    #   We should also infer the type nullability flag better with function metadata on Velox.
-    def with_null(self, nullable: bool):
-        return self.from_velox(
+    def _with_null(self, nullable: bool):
+        return self._from_velox(
             self.device, self.dtype.with_null(nullable), self._data, True
         )
 

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -152,7 +152,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
                 if mask_list[i]:
                     col.set_null_at(i)
 
-        return ColumnFromVelox.from_velox(self.device, dtype, col, True)
+        return ColumnFromVelox._from_velox(self.device, dtype, col, True)
 
     def __len__(self):
         return len(self._data)
@@ -171,7 +171,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             i += len(self._data)
         if not self._getmask(i):
             return tuple(
-                ColumnFromVelox.from_velox(
+                ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[j].dtype,
                     self._data.child_at(j),
@@ -187,7 +187,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         return np.full((ct,), False, dtype=np.bool8)
 
     def copy(self):
-        return ColumnFromVelox.from_velox(self.device, self.dtype, self._data, True)
+        return ColumnFromVelox._from_velox(self.device, self.dtype, self._data, True)
 
     def append(self, values: Iterable[Union[None, dict, tuple]]):
         """Returns column/dataframe with values appended."""
@@ -212,7 +212,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
                     idx = self._data.type().get_child_idx(k)
                     child = self._data.child_at(idx)
                     dtype = self.dtype.fields[idx].dtype
-                    child_col = ColumnFromVelox.from_velox(
+                    child_col = ColumnFromVelox._from_velox(
                         self.device, dtype, child, True
                     )
                     child_col = child_col.append([v])
@@ -288,7 +288,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         return self._fromdata(
             {
                 self.dtype.fields[i]
-                .name: ColumnFromVelox.from_velox(
+                .name: ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[i].dtype,
                     self._data.child_at(i),
@@ -302,7 +302,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     def get_column(self, column):
         idx = self._data.type().get_child_idx(column)
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             self.device,
             self.dtype.fields[idx].dtype,
             self._data.child_at(idx),
@@ -323,7 +323,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         res = {}
         for i in range(_start, _stop):
             m = self.columns[i]
-            res[m] = ColumnFromVelox.from_velox(
+            res[m] = ColumnFromVelox._from_velox(
                 self.device,
                 self.dtype.fields[i].dtype,
                 self._data.child_at(i),
@@ -353,7 +353,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
         if len(columns) == 1:
             idx = self._data.type().get_child_idx(columns[0])
-            return ColumnFromVelox.from_velox(
+            return ColumnFromVelox._from_velox(
                 self.device,
                 self.dtype.fields[idx].dtype,
                 self._data.child_at(idx),
@@ -371,7 +371,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             for n in columns:
                 idx = self._data.type().get_child_idx(n)
                 cols.append(
-                    ColumnFromVelox.from_velox(
+                    ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[idx].dtype,
                         self._data.child_at(idx),
@@ -474,7 +474,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         for n in columns:
             idx = self._data.type().get_child_idx(n)
             cols.append(
-                ColumnFromVelox.from_velox(
+                ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[idx].dtype,
                     self._data.child_at(idx),
@@ -558,13 +558,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    + ColumnFromVelox.from_velox(
+                    + ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -577,7 +577,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -599,7 +599,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             return self._fromdata(
                 {
                     self.dtype.fields[i].name: other
-                    + ColumnFromVelox.from_velox(
+                    + ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -616,13 +616,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    - ColumnFromVelox.from_velox(
+                    - ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -635,7 +635,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -653,13 +653,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
                         True,
                     )
-                    - ColumnFromVelox.from_velox(
+                    - ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -673,7 +673,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             return self._fromdata(
                 {
                     self.dtype.fields[i].name: other
-                    - ColumnFromVelox.from_velox(
+                    - ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -690,13 +690,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    * ColumnFromVelox.from_velox(
+                    * ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -709,7 +709,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -727,13 +727,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
                         True,
                     )
-                    * ColumnFromVelox.from_velox(
+                    * ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -747,7 +747,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             return self._fromdata(
                 {
                     self.dtype.fields[i].name: other
-                    * ColumnFromVelox.from_velox(
+                    * ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -764,13 +764,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    // ColumnFromVelox.from_velox(
+                    // ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -783,7 +783,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -801,13 +801,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
                         True,
                     )
-                    // ColumnFromVelox.from_velox(
+                    // ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -821,7 +821,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             return self._fromdata(
                 {
                     self.dtype.fields[i].name: other
-                    // ColumnFromVelox.from_velox(
+                    // ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -838,13 +838,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    / ColumnFromVelox.from_velox(
+                    / ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -857,7 +857,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -887,7 +887,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -914,13 +914,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    ** ColumnFromVelox.from_velox(
+                    ** ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -933,7 +933,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -951,13 +951,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
                         True,
                     )
-                    ** ColumnFromVelox.from_velox(
+                    ** ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -971,7 +971,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             return self._fromdata(
                 {
                     self.dtype.fields[i].name: other
-                    ** ColumnFromVelox.from_velox(
+                    ** ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -988,13 +988,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    == ColumnFromVelox.from_velox(
+                    == ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -1007,7 +1007,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -1036,13 +1036,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    < ColumnFromVelox.from_velox(
+                    < ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -1055,7 +1055,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -1073,13 +1073,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    > ColumnFromVelox.from_velox(
+                    > ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -1092,7 +1092,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -1112,7 +1112,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -1129,13 +1129,13 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             assert len(self) == len(other)
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
                         True,
                     )
-                    >= ColumnFromVelox.from_velox(
+                    >= ColumnFromVelox._from_velox(
                         other.device,
                         other.dtype.fields[i].dtype,
                         other._data.child_at(i),
@@ -1158,7 +1158,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         else:
             return self._fromdata(
                 {
-                    self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                    self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -1200,7 +1200,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
     def __neg__(self):
         return self._fromdata(
             {
-                self.dtype.fields[i].name: -ColumnFromVelox.from_velox(
+                self.dtype.fields[i].name: -ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[i].dtype,
                     self._data.child_at(i),
@@ -1214,7 +1214,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
     def __pos__(self):
         return self._fromdata(
             {
-                self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[i].dtype,
                     self._data.child_at(i),
@@ -1235,7 +1235,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             return self._fromdata(
                 {
                     self.dtype.fields[i]
-                    .name: ColumnFromVelox.from_velox(
+                    .name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -1272,7 +1272,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             return self._fromdata(
                 {
                     self.dtype.fields[i]
-                    .name: ColumnFromVelox.from_velox(
+                    .name: ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -1471,7 +1471,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         res["column"] = ta.Column([f.name for f in self.dtype.fields], dt.string)
         res["unique"] = ta.Column(
             [
-                ColumnFromVelox.from_velox(
+                ColumnFromVelox._from_velox(
                     self.device,
                     f.dtype,
                     self._data.child_at(self._data.type().get_child_idx(f.name)),
@@ -1488,7 +1488,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
         for i in range(self._data.children_size()):
             result = func(
-                ColumnFromVelox.from_velox(
+                ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[i].dtype,
                     self._data.child_at(i),
@@ -1509,7 +1509,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
             for i in range(self._data.children_size()):
                 child = func(
-                    ColumnFromVelox.from_velox(
+                    ColumnFromVelox._from_velox(
                         self.device,
                         self.dtype.fields[i].dtype,
                         self._data.child_at(i),
@@ -1521,7 +1521,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
                     child._data,
                 )
             res.set_length(len(self._data))
-            return ColumnFromVelox.from_velox(self.device, self.dtype, res, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, res, True)
         raise NotImplementedError("Dataframe row is not allowed to have nulls")
 
     # describe ----------------------------------------------------------------
@@ -1570,7 +1570,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         )
         for s in selected:
             idx = self._data.type().get_child_idx(s)
-            c = ColumnFromVelox.from_velox(
+            c = ColumnFromVelox._from_velox(
                 self.device,
                 self.dtype.fields[idx].dtype,
                 self._data.child_at(idx),
@@ -1594,7 +1594,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         self._check_columns(columns)
         return self._fromdata(
             {
-                self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[i].dtype,
                     self._data.child_at(i),
@@ -1615,7 +1615,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         self._check_columns(columns)
         return self._fromdata(
             {
-                self.dtype.fields[i].name: ColumnFromVelox.from_velox(
+                self.dtype.fields[i].name: ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[i].dtype,
                     self._data.child_at(i),
@@ -1635,7 +1635,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             {
                 column_mapper.get(
                     self.dtype.fields[i].name, self.dtype.fields[i].name
-                ): ColumnFromVelox.from_velox(
+                ): ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[i].dtype,
                     self._data.child_at(i),
@@ -1655,7 +1655,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         self._check_columns(columns)
         return self._fromdata(
             {
-                col: ColumnFromVelox.from_velox(
+                col: ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[self._data.type().get_child_idx(col)].dtype,
                     self._data.child_at(self._data.type().get_child_idx(col)),
@@ -1841,7 +1841,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         for i in range(self._data.children_size()):
             n = self.dtype.fields[i].name
             if n in output_columns:
-                res[n] = ColumnFromVelox.from_velox(
+                res[n] = ColumnFromVelox._from_velox(
                     self.device,
                     self.dtype.fields[i].dtype,
                     self._data.child_at(i),

--- a/torcharrow/velox_rt/functional.py
+++ b/torcharrow/velox_rt/functional.py
@@ -37,7 +37,7 @@ class VeloxFunctional(types.ModuleType):
             # Generic dispatch always assumes nullable
             result_dtype = result_col.dtype().with_null(True)
 
-            return ColumnFromVelox.from_velox(
+            return ColumnFromVelox._from_velox(
                 first_col.device, result_dtype, result_col, True
             )
 
@@ -57,7 +57,7 @@ class VeloxFunctional(types.ModuleType):
             # Generic dispatch always assumes nullable
             result_dtype = result_col.dtype().with_null(True)
 
-            return ColumnFromVelox.from_velox(device, result_dtype, result_col, True)
+            return ColumnFromVelox._from_velox(device, result_dtype, result_col, True)
 
         if op_name in functional_registry._factory_methods:
             return factory_dispatch

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -51,7 +51,7 @@ class ListColumnCpu(ColumnFromVelox, IListColumn):
     def _fromlist(device: str, data: List[List], dtype: dt.List):
         if dt.is_primitive(dtype.item_dtype):
             velox_column = velox.Column(get_velox_type(dtype), data)
-            return ColumnFromVelox.from_velox(
+            return ColumnFromVelox._from_velox(
                 device,
                 dtype,
                 velox_column,
@@ -110,7 +110,7 @@ class ListColumnCpu(ColumnFromVelox, IListColumn):
             return self.dtype.default_value()
         else:
             return list(
-                ColumnFromVelox.from_velox(
+                ColumnFromVelox._from_velox(
                     self.device,
                     self._dtype.item_dtype,
                     self._data[i],
@@ -149,7 +149,7 @@ class ListColumnCpu(ColumnFromVelox, IListColumn):
         # TODO: more efficient/straightfowrad interop
         arrow_array = self.to_arrow()
 
-        elements = ColumnFromVelox.from_velox(
+        elements = ColumnFromVelox._from_velox(
             self.device, self._dtype.item_dtype, self._data.elements(), True
         ).to_torch()
         # special case: if the nested type is List (which happens for List[str] that can't be represented as tensor)

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -9,7 +9,7 @@ import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as pytorch
 from tabulate import tabulate
-from torcharrow import Scope
+from torcharrow.scope import Scope
 from torcharrow.dispatcher import Dispatcher
 from torcharrow.ilist_column import IListColumn, IListMethods
 

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -11,7 +11,7 @@ import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as pytorch
 from tabulate import tabulate
-from torcharrow import Scope
+from torcharrow.scope import Scope
 from torcharrow.dispatcher import Dispatcher
 from torcharrow.dispatcher import Dispatcher
 from torcharrow.icolumn import IColumn

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -127,13 +127,13 @@ class MapColumnCpu(ColumnFromVelox, IMapColumn):
         if self._data.is_null_at(i):
             return self.dtype.default_value()
         else:
-            key_col = ColumnFromVelox.from_velox(
+            key_col = ColumnFromVelox._from_velox(
                 self.device,
                 self._dtype.key_dtype,
                 self._data.keys()[i],
                 True,
             )
-            value_col = ColumnFromVelox.from_velox(
+            value_col = ColumnFromVelox._from_velox(
                 self.device,
                 self._dtype.item_dtype,
                 self._data.values()[i],
@@ -169,10 +169,10 @@ class MapColumnCpu(ColumnFromVelox, IMapColumn):
         # FIXME: https://github.com/facebookresearch/torcharrow/issues/62 to_arrow doesn't work as expected for map
         # arrow_array = self.to_arrow()
 
-        keys = ColumnFromVelox.from_velox(
+        keys = ColumnFromVelox._from_velox(
             self.device, dt.List(self._dtype.key_dtype), self._data.keys(), True
         ).to_torch(_propagate_py_list=False)
-        values = ColumnFromVelox.from_velox(
+        values = ColumnFromVelox._from_velox(
             self.device, dt.List(self._dtype.item_dtype), self._data.values(), True
         ).to_torch(_propagate_py_list=False)
 
@@ -213,12 +213,12 @@ class MapMethodsCpu(IMapMethods):
 
     def keys(self):
         me = self._parent
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             me.device, dt.List(me._dtype.key_dtype), me._data.keys(), True
         )
 
     def values(self):
         me = self._parent
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             me.device, dt.List(me._dtype.item_dtype), me._data.values(), True
         )

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -70,7 +70,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         # to velox_column
         assert c_schema.release == ffi.NULL and c_array.release == ffi.NULL
 
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             device,
             dtype,
             velox_column,

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -42,7 +42,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @staticmethod
     def _fromlist(device: str, data: List[Union[int, float, bool]], dtype: dt.DType):
         velox_column = velox.Column(get_velox_type(dtype), data)
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             device,
             dtype,
             velox_column,
@@ -143,7 +143,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append(
                         then_._getdata(i) if self._getdata(i) else else_._getdata(i)
                     )
-            return ColumnFromVelox.from_velox(self.device, lub, col, True)
+            return ColumnFromVelox._from_velox(self.device, lub, col, True)
 
         else:
             # refer back to default handling...
@@ -182,7 +182,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
             for i in range(none_count):
                 col.append_null()
 
-        return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+        return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
 
     @trace
     @expression
@@ -332,7 +332,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(self._getdata(i) // other._getdata(i))
-            return ColumnFromVelox.from_velox(self.device, dt.float64, col, True)
+            return ColumnFromVelox._from_velox(self.device, dt.float64, col, True)
         else:
             col = velox.Column(get_velox_type(dt.float64))
             for i in range(len(self)):
@@ -340,7 +340,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(self._getdata(i) // other)
-            return ColumnFromVelox.from_velox(self.device, dt.float64, col, True)
+            return ColumnFromVelox._from_velox(self.device, dt.float64, col, True)
 
     @trace
     @expression
@@ -355,7 +355,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(other._getdata(i) // self._getdata(i))
-            return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
         else:
             col = velox.Column(get_velox_type(self.dtype))
             for i in range(len(self)):
@@ -363,7 +363,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(other // self._getdata(i))
-            return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
 
     @trace
     @expression
@@ -381,7 +381,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(self._getdata(i) / other_data)
-            return ColumnFromVelox.from_velox(self.device, dt.float64, col, True)
+            return ColumnFromVelox._from_velox(self.device, dt.float64, col, True)
         else:
             col = velox.Column(get_velox_type(dt.float64))
             for i in range(len(self)):
@@ -391,7 +391,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(self._getdata(i) / other)
-            return ColumnFromVelox.from_velox(self.device, dt.float64, col, True)
+            return ColumnFromVelox._from_velox(self.device, dt.float64, col, True)
 
     @trace
     @expression
@@ -409,7 +409,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(other._getdata(i) / self_data)
-            return ColumnFromVelox.from_velox(self.device, dt.float64, col, True)
+            return ColumnFromVelox._from_velox(self.device, dt.float64, col, True)
         else:
             col = velox.Column(get_velox_type(dt.float64))
             for i in range(len(self)):
@@ -420,7 +420,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(other / self_data)
-            return ColumnFromVelox.from_velox(self.device, dt.float64, col, True)
+            return ColumnFromVelox._from_velox(self.device, dt.float64, col, True)
 
     @trace
     @expression
@@ -447,7 +447,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(self._getdata(i) ** other._getdata(i))
-            return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
         else:
             col = velox.Column(get_velox_type(self.dtype))
             for i in range(len(self)):
@@ -455,7 +455,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(self._getdata(i) ** other)
-            return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
 
     @trace
     @expression
@@ -470,7 +470,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(other._getdata(i) ** self._getdata(i))
-            return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
         else:
             col = velox.Column(get_velox_type(self.dtype))
             for i in range(len(self)):
@@ -478,7 +478,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     col.append_null()
                 else:
                     col.append(other ** self._getdata(i))
-            return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
 
     @trace
     @expression
@@ -561,14 +561,14 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __invert__(self):
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             self.device, self.dtype, self._data.invert(), True
         )
 
     @trace
     @expression
     def __neg__(self):
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             self.device, self.dtype, self._data.neg(), True
         )
 
@@ -588,28 +588,28 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                 col.append(False)
             else:
                 col.append(self._getdata(i) in values)
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             self.device, dt.Boolean(self.dtype.nullable), col, True
         )
 
     @trace
     @expression
     def abs(self):
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             self.device, self.dtype, self._data.abs(), True
         )
 
     @trace
     @expression
     def ceil(self):
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             self.device, self.dtype, self._data.ceil(), True
         )
 
     @trace
     @expression
     def floor(self):
-        return ColumnFromVelox.from_velox(
+        return ColumnFromVelox._from_velox(
             self.device, self.dtype, self._data.floor(), True
         )
 
@@ -619,7 +619,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         self._prototype_support_warning("round")
 
         # TODO: round(-2.5) returns -2.0 in Numpy/PyTorch but returns -3.0 in Velox
-        # return ColumnFromVelox.from_velox(self.device, self.dtype, self._data.round(), True)
+        # return ColumnFromVelox._from_velox(self.device, self.dtype, self._data.round(), True)
 
         col = velox.Column(get_velox_type(self.dtype))
         for i in range(len(self)):
@@ -627,7 +627,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                 col.append_null()
             else:
                 col.append(round(self._getdata(i), decimals))
-        return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+        return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
 
     # data cleaning -----------------------------------------------------------
 
@@ -650,7 +650,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                         col.append(fill_value)
                 else:
                     col.append(self._getdata(i))
-            return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
 
     @trace
     @expression
@@ -666,7 +666,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                     pass
                 else:
                     col.append(self._getdata(i))
-            return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+            return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
 
     @trace
     @expression
@@ -688,7 +688,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                 if current not in seen:
                     col.append(current)
                     seen.add(current)
-        return ColumnFromVelox.from_velox(self.device, self.dtype, col, True)
+        return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
 
     # universal  ---------------------------------------------------------------
 

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -23,7 +23,7 @@ from .typing import get_velox_type
 
 
 class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
-    """A Numerical Column"""
+    """A Numerical Column on Velox backend"""
 
     # private
     def __init__(self, device, dtype, data: velox.BaseColumn):
@@ -99,7 +99,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
 
     @property
     def null_count(self):
-        """Return number of null items"""
         return self._data.get_null_count()
 
     def _getdata(self, i):
@@ -160,7 +159,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         ascending=True,
         na_position="last",
     ):
-        """Sort a column/a dataframe in ascending or descending order"""
         self._prototype_support_warning("sort")
 
         if columns is not None:
@@ -194,7 +192,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         columns: Optional[List[str]] = None,
         keep="first",
     ):
-        """Returns a new data of the *n* largest element."""
         if columns is not None:
             raise TypeError(
                 "computing n-largest on numerical column can't have 'columns' parameter"
@@ -204,7 +201,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def _nsmallest(self, n=5, columns: Optional[List[str]] = None, keep="first"):
-        """Returns a new data of the *n* smallest element."""
         if columns is not None:
             raise TypeError(
                 "computing n-smallest on numerical column can't have 'columns' parameter"
@@ -215,7 +211,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def _nunique(self, drop_null=True):
-        """Returns the number of unique values of the column"""
         self._prototype_support_warning("_nunique")
 
         result = set()
@@ -291,13 +286,11 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __add__(self, other: Union[INumericalColumn, int, float]) -> INumericalColumn:
-        """Vectorized a + b."""
         return self._checked_arithmetic_op_call(other, "add", operator.add)
 
     @trace
     @expression
     def __radd__(self, other: Union[int, float]) -> INumericalColumn:
-        """Vectorized b + a."""
         return self._checked_arithmetic_op_call(
             other, "radd", IColumn._swap(operator.add)
         )
@@ -305,13 +298,11 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __sub__(self, other: Union[INumericalColumn, int, float]) -> INumericalColumn:
-        """Vectorized a - b."""
         return self._checked_arithmetic_op_call(other, "sub", operator.sub)
 
     @trace
     @expression
     def __rsub__(self, other: Union[int, float]) -> INumericalColumn:
-        """Vectorized b - a."""
         return self._checked_arithmetic_op_call(
             other, "rsub", IColumn._swap(operator.sub)
         )
@@ -319,13 +310,11 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __mul__(self, other: Union[INumericalColumn, int, float]) -> INumericalColumn:
-        """Vectorized a * b."""
         return self._checked_arithmetic_op_call(other, "mul", operator.mul)
 
     @trace
     @expression
     def __rmul__(self, other: Union[int, float]) -> INumericalColumn:
-        """Vectorized b * a."""
         return self._checked_arithmetic_op_call(
             other, "rmul", IColumn._swap(operator.mul)
         )
@@ -333,7 +322,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __floordiv__(self, other):
-        """Vectorized a // b."""
         self._prototype_support_warning("__floordiv__")
 
         if isinstance(other, NumericalColumnCpu):
@@ -357,7 +345,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __rfloordiv__(self, other):
-        """Vectorized b // a."""
         self._prototype_support_warning("__rfloordiv__")
 
         if isinstance(other, NumericalColumnCpu):
@@ -381,7 +368,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __truediv__(self, other):
-        """Vectorized a / b."""
         self._prototype_support_warning("__truediv__")
 
         if isinstance(other, NumericalColumnCpu):
@@ -410,7 +396,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __rtruediv__(self, other):
-        """Vectorized b / a."""
         self._prototype_support_warning("__rtruediv__")
 
         if isinstance(other, NumericalColumnCpu):
@@ -440,13 +425,11 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __mod__(self, other: Union[INumericalColumn, int, float]) -> INumericalColumn:
-        """Vectorized a % b."""
         return self._checked_arithmetic_op_call(other, "mod", operator.mod)
 
     @trace
     @expression
     def __rmod__(self, other: Union[int, float]) -> INumericalColumn:
-        """Vectorized b % a."""
         return self._checked_arithmetic_op_call(
             other, "rmod", IColumn._swap(operator.mod)
         )
@@ -454,7 +437,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __pow__(self, other):
-        """Vectorized a ** b."""
         self._prototype_support_warning("__pow__")
 
         if isinstance(other, NumericalColumnCpu):
@@ -478,7 +460,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __rpow__(self, other):
-        """Vectorized b ** a."""
         self._prototype_support_warning("__rpow__")
 
         if isinstance(other, NumericalColumnCpu):
@@ -504,7 +485,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def __eq__(
         self, other: Union[INumericalColumn, List[int], List[float], int, float]
     ):
-        """Vectorized a == b."""
         return self._checked_comparison_op_call(other, "eq")
 
     @trace
@@ -512,7 +492,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def __ne__(
         self, other: Union[INumericalColumn, List[int], List[float], int, float]
     ):
-        """Vectorized a != b."""
         return self._checked_comparison_op_call(other, "neq")
 
     @trace
@@ -520,7 +499,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def __lt__(
         self, other: Union[INumericalColumn, List[int], List[float], int, float]
     ):
-        """Vectorized a < b."""
         return self._checked_comparison_op_call(other, "lt")
 
     @trace
@@ -528,7 +506,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def __gt__(
         self, other: Union[INumericalColumn, List[int], List[float], int, float]
     ):
-        """Vectorized a > b."""
         return self._checked_comparison_op_call(other, "gt")
 
     @trace
@@ -536,7 +513,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def __le__(
         self, other: Union[INumericalColumn, List[int], List[float], int, float]
     ):
-        """Vectorized a <= b."""
         return self._checked_comparison_op_call(other, "lte")
 
     @trace
@@ -544,19 +520,16 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def __ge__(
         self, other: Union[INumericalColumn, List[int], List[float], int, float]
     ):
-        """Vectorized a >= b."""
         return self._checked_comparison_op_call(other, "gte")
 
     @trace
     @expression
     def __and__(self, other: Union[INumericalColumn, int]) -> INumericalColumn:
-        """Vectorized a & b."""
         return self._checked_arithmetic_op_call(other, "bitwise_and", operator.__and__)
 
     @trace
     @expression
     def __rand__(self, other: Union[int]) -> INumericalColumn:
-        """Vectorized b & a."""
         return self._checked_arithmetic_op_call(
             other, "bitwise_rand", IColumn._swap(operator.__and__)
         )
@@ -564,13 +537,11 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __or__(self, other: Union[INumericalColumn, int]) -> INumericalColumn:
-        """Vectorized a | b."""
         return self._checked_arithmetic_op_call(other, "bitwise_or", operator.__or__)
 
     @trace
     @expression
     def __ror__(self, other: Union[int]) -> INumericalColumn:
-        """Vectorized b | a."""
         return self._checked_arithmetic_op_call(
             other, "bitwise_ror", IColumn._swap(operator.__or__)
         )
@@ -578,13 +549,11 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __xor__(self, other: Union[INumericalColumn, int]) -> INumericalColumn:
-        """Vectorized a | b."""
         return self._checked_arithmetic_op_call(other, "bitwise_xor", operator.__xor__)
 
     @trace
     @expression
     def __rxor__(self, other: Union[int]) -> INumericalColumn:
-        """Vectorized b | a."""
         return self._checked_arithmetic_op_call(
             other, "bitwise_rxor", IColumn._swap(operator.__xor__)
         )
@@ -592,7 +561,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __invert__(self):
-        """Vectorized: ~a."""
         return ColumnFromVelox.from_velox(
             self.device, self.dtype, self._data.invert(), True
         )
@@ -600,7 +568,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __neg__(self):
-        """Vectorized: - a."""
         return ColumnFromVelox.from_velox(
             self.device, self.dtype, self._data.neg(), True
         )
@@ -608,18 +575,13 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __pos__(self):
-        """Vectorized: + a."""
         return self
 
     @trace
     @expression
-    def isin(self, values, invert=False):
-        """Check whether list values are contained in data, or column/dataframe (row/column specific)."""
+    def isin(self, values):
         self._prototype_support_warning("isin")
 
-        # Todo decide on wether mask matters?
-        if invert:
-            raise NotImplementedError()
         col = velox.Column(get_velox_type(dt.boolean))
         for i in range(len(self)):
             if self._getmask(i):
@@ -633,7 +595,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def abs(self):
-        """Absolute value of each element of the series."""
         return ColumnFromVelox.from_velox(
             self.device, self.dtype, self._data.abs(), True
         )
@@ -641,7 +602,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def ceil(self):
-        """Rounds each value upward to the smallest integral"""
         return ColumnFromVelox.from_velox(
             self.device, self.dtype, self._data.ceil(), True
         )
@@ -649,7 +609,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def floor(self):
-        """Rounds each value downward to the largest integral value"""
         return ColumnFromVelox.from_velox(
             self.device, self.dtype, self._data.floor(), True
         )
@@ -657,7 +616,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def round(self, decimals=0):
-        """Round each value in a data to the given number of decimals."""
         self._prototype_support_warning("round")
 
         # TODO: round(-2.5) returns -2.0 in Numpy/PyTorch but returns -3.0 in Velox
@@ -676,7 +634,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def fill_null(self, fill_value: Union[dt.ScalarTypes, Dict]):
-        """Fill NA/NaN values using the specified method."""
         self._prototype_support_warning("fill_null")
 
         if not isinstance(fill_value, IColumn._scalar_types):
@@ -698,7 +655,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def drop_null(self, how="any"):
-        """Return a column with rows removed where a row has any or all nulls."""
         self._prototype_support_warning("drop_null")
 
         if not self.is_nullable:
@@ -718,7 +674,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         self,
         subset: Optional[List[str]] = None,
     ):
-        """Remove duplicate values from row/frame"""
         self._prototype_support_warning("drop_duplicates")
 
         if subset is not None:
@@ -740,7 +695,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def all(self):
-        """Return whether all non-null elements are True in Column"""
         self._prototype_support_warning("all")
 
         for i in range(len(self)):
@@ -752,8 +706,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
 
     @trace
     @expression
-    def any(self, skipna=True, boolean_only=None):
-        """Return whether any non-null element is True in Column"""
+    def any(self):
         self._prototype_support_warning("any")
 
         for i in range(len(self)):
@@ -766,8 +719,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def sum(self):
-        # TODO Should be def sum(self, initial=None) but didn't get to work
-        """Return sum of all non-null elements in Column (starting with initial)"""
         self._prototype_support_warning("sum")
 
         result = 0
@@ -808,7 +759,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def _cummin(self):
-        """Return cumulative minimum of the data."""
         self._prototype_support_warning("_cummin")
 
         return self._accumulate_column(min, skipna=True, initial=None)
@@ -816,7 +766,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def _cummax(self):
-        """Return cumulative maximum of the data."""
         self._prototype_support_warning("_cummax")
 
         return self._accumulate_column(max, skipna=True, initial=None)
@@ -824,7 +773,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def cumsum(self):
-        """Return cumulative sum of the data."""
         self._prototype_support_warning("cumsum")
 
         return self._accumulate_column(operator.add, skipna=True, initial=None)
@@ -832,7 +780,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def _cumprod(self):
-        """Return cumulative product of the data."""
         self._prototype_support_warning("_cumprod")
 
         return self._accumulate_column(operator.mul, skipna=True, initial=None)
@@ -840,7 +787,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def mean(self):
-        """Return the mean of the values in the series."""
         self._prototype_support_warning("mean")
 
         return statistics.mean(value for value in self if value is not None)
@@ -848,7 +794,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def median(self):
-        """Return the median of the values in the data."""
         self._prototype_support_warning("median")
 
         return statistics.median(value for value in self if value is not None)
@@ -856,7 +801,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def quantile(self, q, interpolation="midpoint"):
-        """Compute the q-th percentile of non-null data."""
         self._prototype_support_warning("quantile")
 
         if len(self) == 0 or len(q) == 0:
@@ -880,7 +824,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @property  # type: ignore
     @traceproperty
     def is_unique(self):
-        """Return boolean if data values are unique."""
         return self._nunique(drop_null=False) == len(self)
 
     @property  # type: ignore
@@ -888,7 +831,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def is_monotonic_increasing(self):
         self._prototype_support_warning("is_monotonic_increasing")
 
-        """Return boolean if values in the object are monotonic increasing"""
         first = True
         prev = None
         for i in range(len(self)):
@@ -907,7 +849,6 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def is_monotonic_decreasing(self):
         self._prototype_support_warning("is_monotonic_decreasing")
 
-        """Return boolean if values in the object are monotonic decreasing"""
         first = True
         prev = None
         for i in range(len(self)):

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -164,37 +164,31 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
     @trace
     @expression
     def __eq__(self, other):
-        """Return self == other."""
         return self._checked_binary_op_call(other, "eq")
 
     @trace
     @expression
     def __ne__(self, other):
-        """Return self != other."""
         return self._checked_binary_op_call(other, "neq")
 
     @trace
     @expression
     def __lt__(self, other):
-        """Return self < other."""
         return self._checked_binary_op_call(other, "lt")
 
     @trace
     @expression
     def __le__(self, other):
-        """Return self <= other."""
         return self._checked_binary_op_call(other, "lte")
 
     @trace
     @expression
     def __gt__(self, other):
-        """Return self > other."""
         return self._checked_binary_op_call(other, "gt")
 
     @trace
     @expression
     def __ge__(self, other):
-        """Return self >= other."""
         return self._checked_binary_op_call(other, "gte")
 
     # printing ----------------------------------------------------------------


### PR DESCRIPTION
Summary:
with these `from XXX import *`, it's difficult to track the methods/variable get imported to the package level

Also use `__all__` in `__init__.py` for so it shows docstring for global methods in `help(torcharrow)`

Reviewed By: OswinC

Differential Revision: D32858748

