### PR TITLE
Add pad_sequence as an example PyTorch Conversion

### DIFF
--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -303,7 +303,7 @@ class Struct(DType):
             self,
             "_py_type",
             ty.NamedTuple(
-                "_StructGenerated_NamedTuple_" + str(type(self)._py_type_id),
+                "TorchArrowGeneratedStruct_" + str(type(self)._py_type_id),
                 [
                     (fix_name(f.name, idx), f.dtype.py_type)
                     for (idx, f) in enumerate(self.fields)

--- a/torcharrow/test/test_interop_cpu.py
+++ b/torcharrow/test/test_interop_cpu.py
@@ -1,11 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-import numpy as np
-import pyarrow as pa
-import torcharrow.dtypes as dt
 import torcharrow.pytorch as tap
-from torcharrow.scope import Scope
 
 from .test_interop import TestInterop
 
@@ -17,6 +13,10 @@ class TestInteropCpu(TestInterop):
     @unittest.skipUnless(tap.available, "Requires PyTorch")
     def test_to_pytorch(self):
         return self.base_test_to_pytorch()
+
+    @unittest.skipUnless(tap.available, "Requires PyTorch")
+    def test_pad_sequence(self):
+        return self.base_test_pad_sequence()
 
     @unittest.skipUnless(tap.available, "Requires PyTorch")
     def test_pytorch_transform(self):

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -160,7 +160,7 @@ class MapColumnCpu(ColumnFromVelox, IMapColumn):
         return tab + dt.NL + typ
 
     # interop
-    def to_torch(self):
+    def _to_torch_default(self):
         pytorch.ensure_available()
         import torch
 
@@ -171,10 +171,10 @@ class MapColumnCpu(ColumnFromVelox, IMapColumn):
 
         keys = ColumnFromVelox._from_velox(
             self.device, dt.List(self._dtype.key_dtype), self._data.keys(), True
-        ).to_torch(_propagate_py_list=False)
+        )._to_torch_default(_propagate_py_list=False)
         values = ColumnFromVelox._from_velox(
             self.device, dt.List(self._dtype.item_dtype), self._data.values(), True
-        ).to_torch(_propagate_py_list=False)
+        )._to_torch_default(_propagate_py_list=False)
 
         # TODO: should we propagate python list if both keys and vals are lists of strings?
         assert isinstance(keys, pytorch.PackedList)

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -856,7 +856,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
 
         return pa.Array._import_from_c(ptr_array, _dtype_to_arrowtype(self.dtype))
 
-    def to_torch(self):
+    def _to_torch_default(self):
         pytorch.ensure_available()
         import torch
 

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -209,7 +209,7 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
         return tab + dt.NL + typ
 
     # interop
-    def to_torch(self):
+    def _to_torch_default(self):
         # there are no string tensors, so we're using regular python list conversion
         return self.to_pylist()
 


### PR DESCRIPTION
Summary:
Example

        >>> import torcharrow as ta
        >>> import torcharrow.pytorch as tap
        >>> df = ta.DataFrame({"label_ids": [0, 1], "token_ids": [[1, 2, 3, 4, 5], [101, 102]]})

        >>> df
        index    label_ids  token_ids
        -------  -----------  ---------------
            0            0  [1, 2, 3, 4, 5]
            1            1  [101, 102]
        dtype: Struct([Field('label_ids', int64), Field('token_ids', List(int64))]), count: 2, null_count: 0

        >>> df.to_torch({"token_ids": tap.PadSequence(padding_value=-1)})
        TorchArrowStruct_0(
            label_ids=tensor([0, 1]),
            token_ids=tensor([
                [  1,   2,   3,   4,   5],
                [101, 102,  -1,  -1,  -1]]
            )
        )

Differential Revision: D32456444

