### PR TITLE
from_arrow supports taking PyArrow Table

### DIFF
--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -1,38 +1,49 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from typing import Optional, List, Union
+
 import pandas as pd  # type: ignore
 import torcharrow.dtypes as dt
 from torcharrow.scope import Scope
 
 from .dispatcher import Dispatcher
+from .icolumn import IColumn
+from .idataframe import IDataFrame
+from .interop_arrow import _from_arrow_array, _from_arrow_table
 
 
-def from_arrow(data, dtype=None, device=""):
+def from_arrow(
+    data, dtype: Optional[dt.DType] = None, device: str = ""
+) -> Union[IColumn, IDataFrame]:
     """
     Convert arrow array/table to a TorchArrow Column/DataFrame.
     """
-    device = device or Scope.default.device
-
     import pyarrow as pa
-    from torcharrow._interop import _arrowtype_to_dtype
 
     assert isinstance(data, pa.Array) or isinstance(data, pa.Table)
 
-    dtype = dtype or _arrowtype_to_dtype(data.type, data.null_count > 0)
+    if dtype is not None:
+        raise NotImplementedError
+
     device = device or Scope.default.device
 
-    call = Dispatcher.lookup((dtype.typecode + "_fromarrow", device))
+    if isinstance(data, pa.Array):
+        return _from_arrow_array(data, device=device)
+    elif isinstance(data, pa.Table):
+        return _from_arrow_table(data, device=device)
+    else:
+        raise ValueError
 
-    return call(device, data, dtype)
 
-
-def from_pandas(data, dtype=None, device=""):
+def from_pandas(data, dtype: Optional[dt.DType] = None, device: str = ""):
     """
     Convert Pandas series/dataframe to a TorchArrow Column/DataFrame.
     """
     raise NotImplementedError
 
 
-def from_pylist(data, dtype=None, device=""):
+def from_pylist(
+    data: List, dtype: Optional[dt.DType] = None, device: str = ""
+) -> IColumn:
     """
     Convert Python list of scalars or containers to a TorchArrow Column/DataFrame.
     """

--- a/torcharrow/interop_arrow.py
+++ b/torcharrow/interop_arrow.py
@@ -1,0 +1,71 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from typing import Optional
+
+from .dispatcher import Dispatcher
+from .icolumn import IColumn
+from .idataframe import DataFrame, IDataFrame
+from .scope import Scope
+
+
+def _from_arrow_array(
+    array,  # type: pa.Array
+    nullable: Optional[bool] = None,
+    device: str = "",
+) -> IColumn:
+    device = device or Scope.default.device
+
+    import pyarrow as pa
+    from torcharrow._interop import _arrowtype_to_dtype
+
+    assert isinstance(array, pa.Array)
+
+    if nullable is None:
+        # Using the most narrow type we can, we (i) don't restrict in any
+        # way where it can be used (since we can pass a narrower typed
+        # non-null column to a function expecting a nullable type, but not
+        # vice versa), (ii) when we bring in a stricter type system in Velox
+        # to allow functions to only be invokable on non-null types we
+        # increase the amount of places we can use the from_arrow result
+        nullable = array.null_count > 0
+    if not nullable and array.null_count > 0:
+        raise RuntimeError("Cannot store nulls in a non-nullable column")
+    dtype = _arrowtype_to_dtype(array.type, nullable)
+
+    device = device or Scope.default.device
+
+    call = Dispatcher.lookup((dtype.typecode + "_fromarrow", device))
+
+    return call(device, array, dtype)
+
+
+def _from_arrow_table(
+    table,  # type: pa.Table
+    device: str = "",
+) -> IDataFrame:
+    device = device or Scope.default.device
+
+    import pyarrow as pa
+
+    assert isinstance(table, pa.Table)
+
+    # For now Arrow Table -> TA DataFrame is implemented by decomposing the table
+    # into Arrow Arrays and then zero-copy converting the Arrays into TA Columns
+    # and finally constructing a TA DataFrame from the Columns. The parent struct
+    # Array of the Arrow Table (RecordBatch) is not zero-copy converted into TA
+    # DataFrame, which is fine since the heavy part of the entire data is the
+    # Columns and we do zero-copy conversion for them. We will be able to do
+    # zero-copy conversion for the parent struct Array as well once we support
+    # from_arrow for struct type
+
+    # May not be zero-copy here if multiple chunks need to be combined
+    table.combine_chunks()
+
+    df_data = {}
+    for i in range(0, len(table.schema)):
+        field = table.schema.field(i)
+        assert len(table[i].chunks) == 1
+        df_data[field.name] = _from_arrow_array(
+            table[i].chunk(0), field.nullable, device
+        )
+
+    return DataFrame(df_data, device=device)

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -11,14 +11,29 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_arrow_array(self):
         return self.base_test_arrow_array()
 
-    def test_ownership_transferred(self):
-        return self.base_test_ownership_transferred()
+    def test_arrow_table(self):
+        return self.base_test_arrow_table()
 
-    def test_memory_reclaimed(self):
-        return self.base_test_memory_reclaimed()
+    def test_array_ownership_transferred(self):
+        return self.base_test_array_ownership_transferred()
 
-    def test_unsupported_types(self):
-        return self.base_test_unsupported_types()
+    def test_array_memory_reclaimed(self):
+        return self.base_test_array_memory_reclaimed()
+
+    def test_array_unsupported_types(self):
+        return self.base_test_array_unsupported_types()
+
+    def test_table_ownership_transferred(self):
+        return self.base_test_table_ownership_transferred()
+
+    def test_table_memory_reclaimed(self):
+        return self.base_test_table_memory_reclaimed()
+
+    def test_table_unsupported_types(self):
+        return self.base_test_table_unsupported_types()
+
+    def test_nullability(self):
+        return self.base_test_nullability()
 
 
 if __name__ == "__main__":

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -58,7 +58,7 @@ DataOrDTypeOrNone = Optional[Union[Mapping, Sequence, dt.DType]]
 class DataFrameCpu(ColumnFromVelox, IDataFrame):
     """Dataframe, ordered dict of typed columns of the same length"""
 
-    def __init__(self, device, dtype, data):
+    def __init__(self, device: str, dtype: dt.Struct, data: Dict[str, ColumnFromVelox]):
         assert dt.is_struct(dtype)
         IDataFrame.__init__(self, device, dtype)
 
@@ -84,7 +84,12 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     # Any _full requires no further type changes..
     @staticmethod
-    def _full(device, data: Dict[str, ColumnFromVelox], dtype=None, mask=None):
+    def _full(
+        device: str,
+        data: Dict[str, ColumnFromVelox],
+        dtype: Optional[dt.Struct] = None,
+        mask=None,
+    ):
         assert mask is None  # TODO: remove mask parameter in _FullColumn
         cols = data.values()  # TODO: also allow data to be a single Velox RowColumn
         assert all(isinstance(c, ColumnFromVelox) for c in data.values())
@@ -106,12 +111,12 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
     # Any _empty must be followed by a _finalize; no other ops are allowed during this time
 
     @staticmethod
-    def _empty(device, dtype):
+    def _empty(device: str, dtype: dt.Struct):
         field_data = {f.name: Scope._EmptyColumn(f.dtype, device) for f in dtype.fields}
         return DataFrameCpu(device, dtype, field_data)
 
     @staticmethod
-    def _fromlist(device, data: List, dtype):
+    def _fromlist(device: str, data: List, dtype: dt.Struct):
         # default (ineffincient) implementation
         col = DataFrameCpu._empty(device, dtype)
         for i in data:


### PR DESCRIPTION
Summary:
Adding `from_arrow` support for pyarrow table for fixed-size types and string.

Changing `dtype` on-the-fly is not supported yet

Quoting from the comment in the code
    # This is implemented by decomposing the table
    # into Arrow Arrays and then zero-copy converting the Arrays into TA Columns
    # and finally constructing a TA DataFrame from the Columns. The parent struct
    # Array of the Arrow Table (RecordBatch) is not zero-copy converted into TA
    # DataFrame, which is fine since the heavy part of the entire data is the
    # Columns and we do zero-copy conversion for them. We will be able to do
    # zero-copy conversion for the parent struct Array as well once we support
    # from_arrow for struct type

Differential Revision: D32680115

