### PR TITLE
Support zero-copy to_arrow for numeric type columns

### DIFF
--- a/torcharrow/_interop.py
+++ b/torcharrow/_interop.py
@@ -173,7 +173,7 @@ def _pandatype_to_dtype(t, nullable):
     return dt.typeof_nptype(t, nullable)
 
 
-def _arrowtype_to_dtype(t, nullable):
+def _arrowtype_to_dtype(t: pa.DataType, nullable: bool) -> dt.DType:
     if pa.types.is_boolean(t):
         return dt.Boolean(nullable)
     if pa.types.is_int8(t):
@@ -191,3 +191,24 @@ def _arrowtype_to_dtype(t, nullable):
     if pa.types.is_string(t) or pa.types.is_large_string(t):
         return dt.String(nullable)
     raise NotImplementedError(f"Unsupported Arrow type: {str(t)}")
+
+
+def _dtype_to_arrowtype(t: dt.DType) -> pa.DataType:
+    underlying_dtype = dt.get_underlying_dtype(t)
+    if underlying_dtype == dt.boolean:
+        return pa.bool_()
+    elif underlying_dtype == dt.int8:
+        return pa.int8()
+    elif underlying_dtype == dt.int16:
+        return pa.int16()
+    elif underlying_dtype == dt.int32:
+        return pa.int32()
+    elif underlying_dtype == dt.int64:
+        return pa.int64()
+    elif underlying_dtype == dt.float32:
+        return pa.float32()
+    elif underlying_dtype == dt.float64:
+        return pa.float64()
+    elif underlying_dtype == dt.string:
+        return pa.string()
+    raise NotImplementedError(f"Unsupported DType to Arrow type: {str(t)}")

--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -1,38 +1,49 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from typing import Optional, List, Union
+
 import pandas as pd  # type: ignore
 import torcharrow.dtypes as dt
 from torcharrow.scope import Scope
 
 from .dispatcher import Dispatcher
+from .icolumn import IColumn
+from .idataframe import IDataFrame
+from .interop_arrow import _from_arrow_array, _from_arrow_table
 
 
-def from_arrow(data, dtype=None, device=""):
+def from_arrow(
+    data, dtype: Optional[dt.DType] = None, device: str = ""
+) -> Union[IColumn, IDataFrame]:
     """
     Convert arrow array/table to a TorchArrow Column/DataFrame.
     """
-    device = device or Scope.default.device
-
     import pyarrow as pa
-    from torcharrow._interop import _arrowtype_to_dtype
 
     assert isinstance(data, pa.Array) or isinstance(data, pa.Table)
 
-    dtype = dtype or _arrowtype_to_dtype(data.type, data.null_count > 0)
+    if dtype is not None:
+        raise NotImplementedError
+
     device = device or Scope.default.device
 
-    call = Dispatcher.lookup((dtype.typecode + "_fromarrow", device))
+    if isinstance(data, pa.Array):
+        return _from_arrow_array(data, device=device)
+    elif isinstance(data, pa.Table):
+        return _from_arrow_table(data, device=device)
+    else:
+        raise ValueError
 
-    return call(device, data, dtype)
 
-
-def from_pandas(data, dtype=None, device=""):
+def from_pandas(data, dtype: Optional[dt.DType] = None, device: str = ""):
     """
     Convert Pandas series/dataframe to a TorchArrow Column/DataFrame.
     """
     raise NotImplementedError
 
 
-def from_pylist(data, dtype=None, device=""):
+def from_pylist(
+    data: List, dtype: Optional[dt.DType] = None, device: str = ""
+) -> IColumn:
     """
     Convert Python list of scalars or containers to a TorchArrow Column/DataFrame.
     """

--- a/torcharrow/interop_arrow.py
+++ b/torcharrow/interop_arrow.py
@@ -1,0 +1,70 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from typing import Optional
+
+from .dispatcher import Dispatcher
+from .icolumn import IColumn
+from .idataframe import DataFrame, IDataFrame
+from .scope import Scope
+
+
+def _from_arrow_array(
+    array,  # type: pa.Array
+    nullable: Optional[bool] = None,
+    device: str = "",
+) -> IColumn:
+    device = device or Scope.default.device
+
+    import pyarrow as pa
+    from torcharrow._interop import _arrowtype_to_dtype
+
+    assert isinstance(array, pa.Array)
+
+    if nullable is None:
+        # Using the most narrow type we can, we (i) don't restrict in any
+        # way where it can be used (since we can pass a narrower typed
+        # non-null column to a function expecting a nullable type, but not
+        # vice versa), (ii) when we bring in a stricter type system in Velox
+        # to allow functions to only be invokable on non-null types we
+        # increase the amount of places we can use the from_arrow result
+        nullable = array.null_count > 0
+    if not nullable and array.null_count > 0:
+        raise RuntimeError("Cannot store nulls in a non-nullable column")
+    dtype = _arrowtype_to_dtype(array.type, nullable)
+
+    device = device or Scope.default.device
+
+    call = Dispatcher.lookup((dtype.typecode + "_fromarrow", device))
+
+    return call(device, array, dtype)
+
+
+def _from_arrow_table(
+    table,  # type: pa.Table
+    device: str = "",
+) -> IDataFrame:
+    device = device or Scope.default.device
+
+    import pyarrow as pa
+
+    assert isinstance(table, pa.Table)
+
+    # For now Arrow Table -> TA DataFrame is implemented by decomposing the table
+    # into Arrow Arrays and then zero-copy converting the Arrays into TA Columns
+    # and finally constructing a TA DataFrame from the Columns. The parent struct
+    # Array of the Arrow Table (RecordBatch) is not zero-copy converted into TA
+    # DataFrame, which is fine since the heavy part of the entire data is the
+    # Columns and we do zero-copy conversion for them. We will be able to do
+    # zero-copy conversion for the parent struct Array as well once we support
+    # from_arrow for struct type
+
+    # May not be zero-copy here if multiple chunks need to be combined
+    table.combine_chunks()
+
+    df_data = {}
+    for i in range(0, len(table.schema)):
+        field = table.schema.field(i)
+        df_data[field.name] = _from_arrow_array(
+            table[i].chunk(0), field.nullable, device
+        )
+
+    return DataFrame(df_data, device=device)

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -11,14 +11,29 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_arrow_array(self):
         return self.base_test_arrow_array()
 
-    def test_ownership_transferred(self):
-        return self.base_test_ownership_transferred()
+    def test_arrow_table(self):
+        return self.base_test_arrow_table()
 
-    def test_memory_reclaimed(self):
-        return self.base_test_memory_reclaimed()
+    def test_array_ownership_transferred(self):
+        return self.base_test_array_ownership_transferred()
 
-    def test_unsupported_types(self):
-        return self.base_test_unsupported_types()
+    def test_array_memory_reclaimed(self):
+        return self.base_test_array_memory_reclaimed()
+
+    def test_array_unsupported_types(self):
+        return self.base_test_array_unsupported_types()
+
+    def test_table_ownership_transferred(self):
+        return self.base_test_table_ownership_transferred()
+
+    def test_table_memory_reclaimed(self):
+        return self.base_test_table_memory_reclaimed()
+
+    def test_table_unsupported_types(self):
+        return self.base_test_table_unsupported_types()
+
+    def test_nullability(self):
+        return self.base_test_nullability()
 
 
 if __name__ == "__main__":

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -8,11 +8,35 @@ class TestArrowInteropCpu(TestArrowInterop):
     def setUp(self):
         self.device = "cpu"
 
-    def test_arrow_array(self):
-        return self.base_test_arrow_array()
+    def test_from_arrow_array_boolean(self):
+        return self.base_test_from_arrow_array_boolean()
 
-    def test_arrow_table(self):
-        return self.base_test_arrow_table()
+    def test_from_arrow_array_integer(self):
+        return self.base_test_from_arrow_array_integer()
+
+    def test_from_arrow_array_float(self):
+        return self.base_test_from_arrow_array_float()
+
+    def test_from_arrow_array_string(self):
+        return self.base_test_from_arrow_array_string()
+
+    def test_from_arrow_table(self):
+        return self.base_test_from_arrow_table()
+
+    def test_to_arrow_array_boolean(self):
+        return self.base_test_to_arrow_array_boolean
+
+    def test_to_arrow_array_integer(self):
+        return self.base_test_to_arrow_array_integer
+
+    def test_to_arrow_array_float(self):
+        return self.base_test_to_arrow_array_float
+
+    def test_to_arrow_array_string(self):
+        return self.base_test_to_arrow_array_string
+
+    def test_to_arrow_array_slice(self):
+        return self.base_test_to_arrow_array_slice
 
     def test_array_ownership_transferred(self):
         return self.base_test_array_ownership_transferred()

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -58,7 +58,7 @@ DataOrDTypeOrNone = Optional[Union[Mapping, Sequence, dt.DType]]
 class DataFrameCpu(ColumnFromVelox, IDataFrame):
     """Dataframe, ordered dict of typed columns of the same length"""
 
-    def __init__(self, device, dtype, data):
+    def __init__(self, device: str, dtype: dt.Struct, data: Dict[str, ColumnFromVelox]):
         assert dt.is_struct(dtype)
         IDataFrame.__init__(self, device, dtype)
 
@@ -84,7 +84,12 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     # Any _full requires no further type changes..
     @staticmethod
-    def _full(device, data: Dict[str, ColumnFromVelox], dtype=None, mask=None):
+    def _full(
+        device: str,
+        data: Dict[str, ColumnFromVelox],
+        dtype: Optional[dt.Struct] = None,
+        mask=None,
+    ):
         assert mask is None  # TODO: remove mask parameter in _FullColumn
         cols = data.values()  # TODO: also allow data to be a single Velox RowColumn
         assert all(isinstance(c, ColumnFromVelox) for c in data.values())
@@ -106,12 +111,12 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
     # Any _empty must be followed by a _finalize; no other ops are allowed during this time
 
     @staticmethod
-    def _empty(device, dtype):
+    def _empty(device: str, dtype: dt.Struct):
         field_data = {f.name: Scope._EmptyColumn(f.dtype, device) for f in dtype.fields}
         return DataFrameCpu(device, dtype, field_data)
 
     @staticmethod
-    def _fromlist(device, data: List, dtype):
+    def _fromlist(device: str, data: List, dtype: dt.Struct):
         # default (ineffincient) implementation
         col = DataFrameCpu._empty(device, dtype)
         for i in data:

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -1692,6 +1692,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         map = {}
         for n, c in self._field_data.items():
             map[n] = c.to_arrow()
+        # FIXME! nullable
         return pa.table(map)
 
     def to_torch(self):

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -845,6 +845,17 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         return True
 
     # interop
+    def to_arrow(self):
+        import pyarrow as pa
+        from pyarrow.cffi import ffi
+        from torcharrow._interop import _dtype_to_arrowtype
+
+        c_array = ffi.new("struct ArrowArray*")
+        ptr_array = int(ffi.cast("uintptr_t", c_array))
+        self._data._export_to_arrow(ptr_array)
+
+        return pa.Array._import_from_c(ptr_array, _dtype_to_arrowtype(self.dtype))
+
     def to_torch(self):
         pytorch.ensure_available()
         import torch


### PR DESCRIPTION
Summary:
Title. Since Velox doesn't support offset, we will create a new Velox Vector with 0 offset and equal lengths for slices being exported.

Also fixed null count setting issues discovered when converting to Arrow Array

Also added a test to cover `_import_from_arrow`

Reviewed By: wenleix

Differential Revision: D32871058

