### PR TITLE
Support DataFrameCpu.to_arrow()

### DIFF
--- a/torcharrow/_interop.py
+++ b/torcharrow/_interop.py
@@ -173,7 +173,7 @@ def _pandatype_to_dtype(t, nullable):
     return dt.typeof_nptype(t, nullable)
 
 
-def _arrowtype_to_dtype(t, nullable):
+def _arrowtype_to_dtype(t: pa.DataType, nullable: bool) -> dt.DType:
     if pa.types.is_boolean(t):
         return dt.Boolean(nullable)
     if pa.types.is_int8(t):
@@ -191,3 +191,24 @@ def _arrowtype_to_dtype(t, nullable):
     if pa.types.is_string(t) or pa.types.is_large_string(t):
         return dt.String(nullable)
     raise NotImplementedError(f"Unsupported Arrow type: {str(t)}")
+
+
+def _dtype_to_arrowtype(t: dt.DType) -> pa.DataType:
+    underlying_dtype = dt.get_underlying_dtype(t)
+    if underlying_dtype == dt.boolean:
+        return pa.bool_()
+    elif underlying_dtype == dt.int8:
+        return pa.int8()
+    elif underlying_dtype == dt.int16:
+        return pa.int16()
+    elif underlying_dtype == dt.int32:
+        return pa.int32()
+    elif underlying_dtype == dt.int64:
+        return pa.int64()
+    elif underlying_dtype == dt.float32:
+        return pa.float32()
+    elif underlying_dtype == dt.float64:
+        return pa.float64()
+    elif underlying_dtype == dt.string:
+        return pa.string()
+    raise NotImplementedError(f"Unsupported DType to Arrow type: {str(t)}")

--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -1,14 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from typing import Optional, List, Union
 
-import pandas as pd  # type: ignore
 import torcharrow.dtypes as dt
-from torcharrow.scope import Scope
 
-from .dispatcher import Dispatcher
 from .icolumn import IColumn
 from .idataframe import IDataFrame
 from .interop_arrow import _from_arrow_array, _from_arrow_table
+from .scope import Scope
 
 
 def from_arrow(
@@ -21,15 +19,12 @@ def from_arrow(
 
     assert isinstance(data, pa.Array) or isinstance(data, pa.Table)
 
-    if dtype is not None:
-        raise NotImplementedError
-
     device = device or Scope.default.device
 
     if isinstance(data, pa.Array):
-        return _from_arrow_array(data, device=device)
+        return _from_arrow_array(data, dtype, device=device)
     elif isinstance(data, pa.Table):
-        return _from_arrow_table(data, device=device)
+        return _from_arrow_table(data, dtype, device=device)
     else:
         raise ValueError
 

--- a/torcharrow/interop_arrow.py
+++ b/torcharrow/interop_arrow.py
@@ -1,6 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from typing import Optional
 
+import torcharrow.dtypes as dt
+
 from .dispatcher import Dispatcher
 from .icolumn import IColumn
 from .idataframe import DataFrame, IDataFrame
@@ -9,7 +11,7 @@ from .scope import Scope
 
 def _from_arrow_array(
     array,  # type: pa.Array
-    nullable: Optional[bool] = None,
+    dtype: Optional[dt.DType] = None,
     device: str = "",
 ) -> IColumn:
     device = device or Scope.default.device
@@ -19,17 +21,21 @@ def _from_arrow_array(
 
     assert isinstance(array, pa.Array)
 
-    if nullable is None:
-        # Using the most narrow type we can, we (i) don't restrict in any
-        # way where it can be used (since we can pass a narrower typed
-        # non-null column to a function expecting a nullable type, but not
-        # vice versa), (ii) when we bring in a stricter type system in Velox
-        # to allow functions to only be invokable on non-null types we
-        # increase the amount of places we can use the from_arrow result
-        nullable = array.null_count > 0
-    if not nullable and array.null_count > 0:
-        raise RuntimeError("Cannot store nulls in a non-nullable column")
-    dtype = _arrowtype_to_dtype(array.type, nullable)
+    # Using the most narrow type we can, we (i) don't restrict in any
+    # way where it can be used (since we can pass a narrower typed
+    # non-null column to a function expecting a nullable type, but not
+    # vice versa), (ii) when we bring in a stricter type system in Velox
+    # to allow functions to only be invokable on non-null types we
+    # increase the amount of places we can use the from_arrow result
+    dtype_from_arrowtype = _arrowtype_to_dtype(array.type, array.null_count > 0)
+    if dtype and (
+        dt.get_underlying_dtype(dtype) != dt.get_underlying_dtype(dtype_from_arrowtype)
+    ):
+        raise NotImplementedError("Type casting is not supported")
+    dtype = dtype or dtype_from_arrowtype
+
+    if not dtype.nullable and array.null_count > 0:
+        raise ValueError("Cannot store nulls in a non-nullable column")
 
     device = device or Scope.default.device
 
@@ -40,13 +46,17 @@ def _from_arrow_array(
 
 def _from_arrow_table(
     table,  # type: pa.Table
+    dtype: Optional[dt.DType] = None,
     device: str = "",
 ) -> IDataFrame:
     device = device or Scope.default.device
 
     import pyarrow as pa
+    from torcharrow._interop import _arrowtype_to_dtype
 
     assert isinstance(table, pa.Table)
+    if dtype:
+        assert dt.is_struct(dtype)
 
     # For now Arrow Table -> TA DataFrame is implemented by decomposing the table
     # into Arrow Arrays and then zero-copy converting the Arrays into TA Columns
@@ -63,9 +73,16 @@ def _from_arrow_table(
     df_data = {}
     for i in range(0, len(table.schema)):
         field = table.schema.field(i)
+
         assert len(table[i].chunks) == 1
         df_data[field.name] = _from_arrow_array(
-            table[i].chunk(0), field.nullable, device
+            table[i].chunk(0),
+            dtype=(
+                dtype.get(field.name)
+                if dtype is not None
+                else _arrowtype_to_dtype(field.type, field.nullable)
+            ),
+            device=device,
         )
 
     return DataFrame(df_data, device=device)

--- a/torcharrow/test/test_arrow_interop.py
+++ b/torcharrow/test/test_arrow_interop.py
@@ -178,6 +178,27 @@ class TestArrowInterop(unittest.TestCase):
         self.assertEqual(s.to_pylist(), list(t_slice))
         self.assertEqual(s.is_valid(), [True, True, False])
 
+    def base_test_to_arrow_table(self):
+        df = ta.DataFrame(
+            {
+                "f1": [1, 2, 3],
+                "f2": ["foo", "bar", None],
+                "f3": [3.0, 1, 2.4],
+            },
+            device=self.device,
+        )
+        pt = df.to_arrow()
+        self.assertTrue(isinstance(pt, pa.Table))
+        self.assertTrue(dt.is_struct(df.dtype))
+        self.assertEqual(len(df), len(pt))
+        for (i, ta_field) in enumerate(df.dtype.fields):
+            pa_field = pt.schema.field(i)
+            self.assertEqual(ta_field.name, pa_field.name)
+            self.assertEqual(
+                ta_field.dtype, _arrowtype_to_dtype(pa_field.type, pa_field.nullable)
+            )
+            self.assertEqual(list(df[ta_field.name]), pt[i].to_pylist())
+
     def base_test_array_ownership_transferred(self):
         pydata = [1, 2, 3]
         s = pa.array(pydata)

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -38,6 +38,9 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_to_arrow_array_slice(self):
         return self.base_test_to_arrow_array_slice
 
+    def test_to_arrow_table(self):
+        return self.base_test_to_arrow_table
+
     def test_array_ownership_transferred(self):
         return self.base_test_array_ownership_transferred()
 

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -8,11 +8,35 @@ class TestArrowInteropCpu(TestArrowInterop):
     def setUp(self):
         self.device = "cpu"
 
-    def test_arrow_array(self):
-        return self.base_test_arrow_array()
+    def test_from_arrow_array_boolean(self):
+        return self.base_test_from_arrow_array_boolean()
 
-    def test_arrow_table(self):
-        return self.base_test_arrow_table()
+    def test_from_arrow_array_integer(self):
+        return self.base_test_from_arrow_array_integer()
+
+    def test_from_arrow_array_float(self):
+        return self.base_test_from_arrow_array_float()
+
+    def test_from_arrow_array_string(self):
+        return self.base_test_from_arrow_array_string()
+
+    def test_from_arrow_table(self):
+        return self.base_test_from_arrow_table()
+
+    def test_to_arrow_array_boolean(self):
+        return self.base_test_to_arrow_array_boolean
+
+    def test_to_arrow_array_integer(self):
+        return self.base_test_to_arrow_array_integer
+
+    def test_to_arrow_array_float(self):
+        return self.base_test_to_arrow_array_float
+
+    def test_to_arrow_array_string(self):
+        return self.base_test_to_arrow_array_string
+
+    def test_to_arrow_array_slice(self):
+        return self.base_test_to_arrow_array_slice
 
     def test_array_ownership_transferred(self):
         return self.base_test_array_ownership_transferred()

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -1692,6 +1692,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
         map = {}
         for n, c in self._field_data.items():
             map[n] = c.to_arrow()
+        # FIXME! nullable
         return pa.table(map)
 
     def to_torch(self):

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -845,6 +845,17 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         return True
 
     # interop
+    def to_arrow(self):
+        import pyarrow as pa
+        from pyarrow.cffi import ffi
+        from torcharrow._interop import _dtype_to_arrowtype
+
+        c_array = ffi.new("struct ArrowArray*")
+        ptr_array = int(ffi.cast("uintptr_t", c_array))
+        self._data._export_to_arrow(ptr_array)
+
+        return pa.Array._import_from_c(ptr_array, _dtype_to_arrowtype(self.dtype))
+
     def to_torch(self):
         pytorch.ensure_available()
         import torch


### PR DESCRIPTION
Summary: Title. Like `from_arrow`, current implementation is to convert columns into Arrow Arrays and then create an Arrow Table from the Arrays. A direct TA DataFrame to Arrow Table conversion needs the support of Velox RowVector -> Struct ArrowArray, which is TBD.

Reviewed By: bhuang3

Differential Revision: D32950497

