### PR TITLE
Use fast construction from pylist in DataFrameCpu.map()

### DIFF
--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -384,15 +384,15 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
                     )
                 )
 
-            res = Scope.default._EmptyColumn(dtype)
+            res = []
             for i in range(len(self)):
                 if self.is_valid_at(i):
-                    res._append(func(*[col[i] for col in cols]))
+                    res.append(func(*[col[i] for col in cols]))
                 elif na_action is None:
-                    res._append(func(None))
+                    res.append(func(None))
                 else:
-                    res._append(None)
-            return res._finalize()
+                    res.append(None)
+            return Scope._FromPyList(res, dtype)
 
     @trace
     @expression


### PR DESCRIPTION
Summary:
Title. Replace the slow construction path through `append` by `_FromPyList`

Timed the speed using [the script](https://www-ai--shift-co-jp.translate.goog/techblog/2291?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en-US) provided by AI Shift. About 30% improvement for this particular test case (the speed difference can be 4X up in different settings, according to previous experiments)
```
# By `append`
[torcharrow] done in 0.05388 s
```
```
# By `FromPyList`
[torcharrow] done in 0.03865 s
```

The test script:
```
  1 import torcharrow as ta
  2 import torcharrow.dtypes as dt
  3
  4 import time
  5 from contextlib import contextmanager
  6
  7 contextmanager
  8 def timer(name):
  9         t0 = time.time()
 10         yield
 11         print(f'[{name}] done in {time.time() - t0:.5f} s')
 12
 13 def avg_math_eng_1(a, b):
 14         return (a + b)/2
 15
 16 d = {
 17         'Japanese': [60, 40, 50, 60]*1000,
 18         'Math': [90, 10, 30, 40]*1000,
 19         'English': [70, 20, 80, 40]*1000,
 20 }
 21 ta_df = ta.DataFrame(d)
 22
 23 with timer('torcharrow'):
 24         ta_df.map(avg_math_eng_1, columns=['Math', 'English'], dtype=dt.float32)
```

Reviewed By: wenleix

Differential Revision: D33049948

