### PR TITLE
Add `IDataFrame.drop` abstract method

### DIFF
--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -208,6 +208,10 @@ class IDataFrame(IColumn):
         raise self._not_supported("copy")
 
     @trace
+    def drop(self, columns: List[str]):
+        raise self._not_supported("drop")
+
+    @trace
     @expression
     def transform(
         self,


### PR DESCRIPTION
Summary: For users who want to call `drop` on `IDataFrame`

Differential Revision: D33152335

