### PR TITLE
Fix a bug in combining chunks in a table

### DIFF
--- a/torcharrow/interop_arrow.py
+++ b/torcharrow/interop_arrow.py
@@ -68,7 +68,7 @@ def _from_arrow_table(
     # from_arrow for struct type
 
     # May not be zero-copy here if multiple chunks need to be combined
-    table.combine_chunks()
+    table = table.combine_chunks()
 
     df_data = {}
     for i in range(0, len(table.schema)):

--- a/torcharrow/test/test_arrow_interop.py
+++ b/torcharrow/test/test_arrow_interop.py
@@ -118,6 +118,21 @@ class TestArrowInterop(unittest.TestCase):
             )
             self.assertEqual(list(df[ta_field.name]), pt[i].to_pylist())
 
+    def base_test_from_arrow_table_with_chunked_arrays(self):
+        chunked = pa.chunked_array([[1, 2, 3], [4, 5, 6]])
+        pt = pa.table({"f1": chunked})
+        df = ta.from_arrow(pt, device=self.device)
+        self.assertTrue(isinstance(df, IDataFrame))
+        self.assertTrue(dt.is_struct(df.dtype))
+        self.assertEqual(len(df), len(pt))
+        for (i, ta_field) in enumerate(df.dtype.fields):
+            pa_field = pt.schema.field(i)
+            self.assertEqual(ta_field.name, pa_field.name)
+            self.assertEqual(
+                ta_field.dtype, _arrowtype_to_dtype(pa_field.type, pa_field.nullable)
+            )
+            self.assertEqual(list(df[ta_field.name]), pt[i].to_pylist())
+
     def _test_to_arrow_array_numeric(
         self, pydata: List, dtype: dt.DType, expected_arrowtype: pa.DataType
     ):

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -23,6 +23,9 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_from_arrow_table(self):
         return self.base_test_from_arrow_table()
 
+    def test_from_arrow_table_with_chunked_arrays(self):
+        return self.base_test_from_arrow_table_with_chunked_arrays()
+
     def test_to_arrow_array_boolean(self):
         return self.base_test_to_arrow_array_boolean
 


### PR DESCRIPTION
Summary: `combine_chunks()` is const. Forgot to update the handle with the returned from `combine_chunks()`

Differential Revision: D33234089

