### PR TITLE
Fix broken cast() method

### DIFF
--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -10,7 +10,7 @@ import statistics
 import typing as ty
 import warnings
 from collections import OrderedDict, defaultdict
-from functools import partial, reduce
+from functools import partial
 
 import numpy as np
 import torcharrow as ta
@@ -242,11 +242,11 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             if dt.is_primitive(dtype):
                 fun = dt.cast_as(dtype)
                 res = Scope._EmptyColumn(dtype)
-                for m, i in self.item():
+                for m, i in self._items():
                     if m:
                         res._append_null()
                     else:
-                        res.append_value(fun(i))
+                        res._append_value(fun(i))
                 return res._finalize()
             else:
                 raise TypeError('f"{astype}({dtype}) is not supported")')

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -483,6 +483,18 @@ class TestNumericalColumn(unittest.TestCase):
             ],
         )
 
+    def base_test_cast(self):
+        data = [1, 2, 3]
+        col_int64 = ta.Column(data, device="cpu")
+        col2_int32 = col_int64.cast(dt.int32)
+        self.assertEqual(list(col2_int32), data)
+        self.assertEqual(col2_int32.dtype, dt.int32)
+
+        data2 = [1, 2, None]
+        col3 = ta.Column(data2, device="cpu", dtype=dt.int32)
+        self.assertEqual(col3.cast(dt.float64).dtype, dt.float64)
+        self.assertEqual(list(col3.cast(dt.float64)), data2)
+
     # experimental
     def base_test_batch_collate(self):
         c = ta.Column([1, 2, 3, 4, 5, 6, 7], device=self.device)


### PR DESCRIPTION
Summary: cast() was broken before, so this diff fixes the broken methods.

Reviewed By: OswinC

Differential Revision: D33296859

