### PR TITLE
Some column getting API adjustment

### DIFF
--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -327,9 +327,9 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                 raise TypeError(
                     f"slice arguments {[type(a) for a in args]} should all be int or string"
                 )
-        elif isinstance(arg, (tuple, list)):
+        elif isinstance(arg, list):
             if len(arg) == 0:
-                return self
+                return ta.DataFrame(device=self.device)
             if all(isinstance(a, bool) for a in arg):
                 return self.filter(arg)
             if all(isinstance(a, int) for a in arg):

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     Iterable,
     List,
+    Dict,
     Mapping,
     Optional,
     Sequence,
@@ -208,11 +209,30 @@ class IDataFrame(IColumn):
         raise self._not_supported("copy")
 
     @trace
+    @expression
     def drop(self, columns: List[str]):
         """
         Returns DataFrame without the removed columns.
         """
         raise self._not_supported("drop")
+
+    @trace
+    @expression
+    def rename(self, mapper: Dict[str, str]):
+        """
+        Returns DataFrame with column names remapped.
+        """
+        raise self._not_supported("rename")
+
+    @trace
+    @expression
+    def reorder(self, columns: List[str]):
+        """
+        EXPERIMENTAL API
+
+        Returns DataFrame with the columns in the prescribed order.
+        """
+        raise self._not_supported("rename")
 
     @trace
     @expression

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -742,8 +742,8 @@ class TestDataFrame(unittest.TestCase):
         self.assertEqual(list(df.drop([])), [(1, 11, 111), (2, 22, 222), (3, 33, 333)])
         self.assertEqual(list(df.drop(["c", "a"])), [(11,), (22,), (33,)])
 
-        self.assertEqual(list(df.keep([])), [])
-        self.assertEqual(list(df.keep(["c", "a"])), [(1, 111), (2, 222), (3, 333)])
+        self.assertEqual(list(df[[]]), [])
+        self.assertEqual(list(df[["a", "c"]]), [(1, 111), (2, 222), (3, 333)])
 
         self.assertEqual(
             list(df.rename({"a": "c", "c": "a"})),
@@ -784,7 +784,7 @@ class TestDataFrame(unittest.TestCase):
 
         self.assertEqual(list(df.select("*")), list(df))
 
-        self.assertEqual(list(df.select("a")), list(df.keep(["a"])))
+        self.assertEqual(list(df.select("a")), list(df[["a"]]))
         self.assertEqual(list(df.select("*", "-a")), list(df.drop(["a"])))
 
         gf = ta.DataFrame(

--- a/torcharrow/test/test_trace.py
+++ b/torcharrow/test/test_trace.py
@@ -228,7 +228,7 @@ class TestDataframeTrace(unittest.TestCase):
         df["d"] = c1
 
         d1 = df.drop(["a"])
-        d2 = df.keep(["a", "c"])
+        d2 = df[["a", "c"]]
         # TODO Clarify: Why did we have in 0.2 this as an  self.assertRaises(AttributeError):
         # AttributeError: cannot override existing column d
         # simply overrides the column name, but that's ok...
@@ -246,7 +246,7 @@ class TestDataframeTrace(unittest.TestCase):
         df["d"] = c1
 
         d1 = df.drop(["a"])
-        d2 = df.keep(["a", "c"])
+        d2 = df[["a", "c"]]
         d3 = d2.rename({"c": "e"})
 
         d4 = d3.min()
@@ -260,7 +260,7 @@ class TestDataframeTrace(unittest.TestCase):
             "c4 = torcharrow.icolumn.IColumn.__getitem__(c0, 'a')",
             "_ = torcharrow.idataframe.IDataFrame.__setitem__(c0, 'd', c4)",
             "c11 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.drop(c0, ['a'])",
-            "c16 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.keep(c0, ['a', 'c'])",
+            "c16 = torcharrow.icolumn.IColumn.__getitem__(c0, ['a', 'c'])",
             "c21 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.rename(c16, {'c': 'e'})",
             "c24 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.min(c21)",
         ]

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -1619,7 +1619,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     @trace
     @expression
-    def keep(self, columns: List[str]):
+    def _keep(self, columns: List[str]):
         """
         Returns DataFrame with the kept columns only.
         """
@@ -1640,11 +1640,11 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     @trace
     @expression
-    def rename(self, column_mapper: Dict[str, str]):
-        self._check_columns(column_mapper.keys())
+    def rename(self, mapper: Dict[str, str]):
+        self._check_columns(mapper.keys())
         return self._fromdata(
             {
-                column_mapper.get(
+                mapper.get(
                     self.dtype.fields[i].name, self.dtype.fields[i].name
                 ): ColumnFromVelox._from_velox(
                     self.device,
@@ -1660,9 +1660,6 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
     @trace
     @expression
     def reorder(self, columns: List[str]):
-        """
-        Returns DataFrame with the columns in the prescribed order.
-        """
         self._check_columns(columns)
         return self._fromdata(
             {


### PR DESCRIPTION
Summary:
1. Put `rename` in IDataFrame. Parameter name changed to `mapper` to be consistent with Pandas
2. Put `reorder` in IDataFrame. Pandas use `reindex`: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.reindex.html . But since TorchArrow doesn't support complicated indexing so `reorder` seems a reasonable name.
3. Move `keep` as private: Not in Pandas; and we can simply use `df[["col1", "col2"]]`.
    * A minor difference, though, is `df.keep(["col1", "col2"])` will keep the column ordering in original DF, while `df[["col1", "col2"]]` will keep column ordering as "col1", "col2"
4. Also remove the support for tuple in `__get_item__` to be consitent with Pandas:

```
>>> df = pd.DataFrame({"a": [1,2 , 3], "b": [4, 5, 6]})
>>> df[["a", "b"]]
   a  b
0  1  4
1  2  5
2  3  6
>>> df[("a", "b")]
Traceback (most recent call last):
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexes/base.py", line 3361, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 76, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 108, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 5198, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 5206, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: ('a', 'b')

>>> a = df["a"]
>>> a[[1, 2]]
1    2
2    3
Name: a, dtype: int64
>>> a[(1, 2)]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/series.py", line 966, in __getitem__
    return self._get_with(key)
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/series.py", line 981, in _get_with
    return self._get_values_tuple(key)
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/series.py", line 1016, in _get_values_tuple
    raise KeyError("key of type tuple not found and not a MultiIndex")
KeyError: 'key of type tuple not found and not a MultiIndex'
```

Reviewed By: dracifer

Differential Revision: D33288400

