### PR TITLE
More column getting API adjustment

### DIFF
--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -327,9 +327,9 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                 raise TypeError(
                     f"slice arguments {[type(a) for a in args]} should all be int or string"
                 )
-        elif isinstance(arg, (tuple, list)):
+        elif isinstance(arg, list):
             if len(arg) == 0:
-                return self
+                return ta.DataFrame(device=self.device)
             if all(isinstance(a, bool) for a in arg):
                 return self.filter(arg)
             if all(isinstance(a, int) for a in arg):

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -309,7 +309,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         if isinstance(arg, int):
             return self._get(arg)
         elif isinstance(arg, str):
-            return self.get_column(arg)
+            return self._get_column(arg)
         elif isinstance(arg, slice):
             args = []
             for i in [arg.start, arg.stop, arg.step]:
@@ -319,13 +319,9 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                     args.append(i)
             if all(a is None or isinstance(a, int) for a in args):
                 return self._slice(*args)
-            elif all(a is None or isinstance(a, str) for a in args):
-                if arg.step is not None:
-                    raise TypeError(f"column slice can't have step argument {arg.step}")
-                return self.slice_columns(arg.start, arg.stop)
             else:
                 raise TypeError(
-                    f"slice arguments {[type(a) for a in args]} should all be int or string"
+                    f"slice arguments {[type(a) for a in args]} should all be int"
                 )
         elif isinstance(arg, list):
             if len(arg) == 0:
@@ -335,7 +331,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             if all(isinstance(a, int) for a in arg):
                 return self._gets(arg)
             if all(isinstance(a, str) for a in arg):
-                return self.get_columns(arg)
+                return self._get_columns(arg)
             else:
                 raise TypeError("index should be list of int or list of str")
         elif isinstance(arg, IColumn) and dt.is_boolean(arg.dtype):

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     Iterable,
     List,
+    Dict,
     Mapping,
     Optional,
     Sequence,
@@ -208,11 +209,30 @@ class IDataFrame(IColumn):
         raise self._not_supported("copy")
 
     @trace
+    @expression
     def drop(self, columns: List[str]):
         """
         Returns DataFrame without the removed columns.
         """
         raise self._not_supported("drop")
+
+    @trace
+    @expression
+    def rename(self, mapper: Dict[str, str]):
+        """
+        Returns DataFrame with column names remapped.
+        """
+        raise self._not_supported("rename")
+
+    @trace
+    @expression
+    def reorder(self, columns: List[str]):
+        """
+        EXPERIMENTAL API
+
+        Returns DataFrame with the columns in the prescribed order.
+        """
+        raise self._not_supported("rename")
 
     @trace
     @expression

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -274,18 +274,6 @@ class IDataFrame(IColumn):
             )
         return self._format_transform_result(raw_res, format, dtype, len(self))
 
-    def get_column(self, column):
-        """Return the named column"""
-        raise self._not_supported("get_column")
-
-    def get_columns(self, columns):
-        """Return a new dataframe referencing the columns[s1],..,column[sm]"""
-        raise self._not_supported("get_columns")
-
-    def slice_columns(self, start, stop):
-        """Return a new dataframe with the slice rows[start:stop]"""
-        raise self._not_supported("slice_columns")
-
     @trace
     def to_pylist(self):
         tup_type = self._dtype.py_type
@@ -293,6 +281,18 @@ class IDataFrame(IColumn):
             tup_type(*v)
             for v in zip(*(self[f.name].to_pylist() for f in self._dtype.fields))
         ]
+
+    def _get_column(self, column):
+        """Return the named column"""
+        raise self._not_supported("get_column")
+
+    def _get_columns(self, columns):
+        """Return a new dataframe referencing the columns[s1],..,column[sm]"""
+        raise self._not_supported("get_columns")
+
+    def _slice_columns(self, start, stop):
+        """Return a new dataframe with the slice rows[start:stop]"""
+        raise self._not_supported("slice_columns")
 
 
 # TODO Make this abstract and add all the abstract methods here ...

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -102,10 +102,10 @@ class TestDataFrame(unittest.TestCase):
         numpy.testing.assert_almost_equal(list(df[["a", "c"]]["c"]), [1.1, 2.2, 3.3])
 
         # slice
-
-        self.assertEqual(df[:"b"].columns, ["a"])
-        self.assertEqual(df["b":].columns, ["b", "c"])
-        self.assertEqual(df["a":"c"].columns, ["a", "b"])
+        # TODO: shall we support slice via column name?
+        # self.assertEqual(df[:"b"].columns, ["a"])
+        # self.assertEqual(df["b":].columns, ["b", "c"])
+        # self.assertEqual(df["a":"c"].columns, ["a", "b"])
 
     def base_test_construction(self):
         # Column type is List of Struct

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -742,8 +742,8 @@ class TestDataFrame(unittest.TestCase):
         self.assertEqual(list(df.drop([])), [(1, 11, 111), (2, 22, 222), (3, 33, 333)])
         self.assertEqual(list(df.drop(["c", "a"])), [(11,), (22,), (33,)])
 
-        self.assertEqual(list(df.keep([])), [])
-        self.assertEqual(list(df.keep(["c", "a"])), [(1, 111), (2, 222), (3, 333)])
+        self.assertEqual(list(df[[]]), [])
+        self.assertEqual(list(df[["a", "c"]]), [(1, 111), (2, 222), (3, 333)])
 
         self.assertEqual(
             list(df.rename({"a": "c", "c": "a"})),
@@ -784,7 +784,11 @@ class TestDataFrame(unittest.TestCase):
 
         self.assertEqual(list(df.select("*")), list(df))
 
-        self.assertEqual(list(df.select("a")), list(df.keep(["a"])))
+        self.assertEqual(list(df.select("a")), list(df[["a"]]))
+        self.assertEqual(list(df.select("a", "b")), list(df[["a", "b"]]))
+        # df.select("b", "a") will keep the original column ordering ("a, b"),
+        #   is this the expected behavior?
+        self.assertEqual(list(df.select(b=me["b"], a=me["a"])), list(df[["b", "a"]]))
         self.assertEqual(list(df.select("*", "-a")), list(df.drop(["a"])))
 
         gf = ta.DataFrame(

--- a/torcharrow/test/test_trace.py
+++ b/torcharrow/test/test_trace.py
@@ -228,7 +228,7 @@ class TestDataframeTrace(unittest.TestCase):
         df["d"] = c1
 
         d1 = df.drop(["a"])
-        d2 = df.keep(["a", "c"])
+        d2 = df[["a", "c"]]
         # TODO Clarify: Why did we have in 0.2 this as an  self.assertRaises(AttributeError):
         # AttributeError: cannot override existing column d
         # simply overrides the column name, but that's ok...
@@ -246,7 +246,7 @@ class TestDataframeTrace(unittest.TestCase):
         df["d"] = c1
 
         d1 = df.drop(["a"])
-        d2 = df.keep(["a", "c"])
+        d2 = df[["a", "c"]]
         d3 = d2.rename({"c": "e"})
 
         d4 = d3.min()
@@ -260,7 +260,7 @@ class TestDataframeTrace(unittest.TestCase):
             "c4 = torcharrow.icolumn.IColumn.__getitem__(c0, 'a')",
             "_ = torcharrow.idataframe.IDataFrame.__setitem__(c0, 'd', c4)",
             "c11 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.drop(c0, ['a'])",
-            "c16 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.keep(c0, ['a', 'c'])",
+            "c16 = torcharrow.icolumn.IColumn.__getitem__(c0, ['a', 'c'])",
             "c21 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.rename(c16, {'c': 'e'})",
             "c24 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.min(c21)",
         ]

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -305,7 +305,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             mask,
         )
 
-    def get_column(self, column):
+    def _get_column(self, column):
         idx = self._data.type().get_child_idx(column)
         return ColumnFromVelox._from_velox(
             self.device,
@@ -314,14 +314,14 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             True,
         )
 
-    def get_columns(self, columns):
+    def _get_columns(self, columns):
         # TODO: decide on nulls, here we assume all defined (mask = False) for new parent...
         res = {}
         for n in columns:
-            res[n] = self.get_column(n)
+            res[n] = self._get_column(n)
         return self._fromdata(res, self._mask)
 
-    def slice_columns(self, start, stop):
+    def _slice_columns(self, start, stop):
         # TODO: decide on nulls, here we assume all defined (mask = False) for new parent...
         _start = 0 if start is None else self._column_index(start)
         _stop = len(self.columns) if stop is None else self._column_index(stop)

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -1619,7 +1619,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     @trace
     @expression
-    def keep(self, columns: List[str]):
+    def _keep(self, columns: List[str]):
         """
         Returns DataFrame with the kept columns only.
         """
@@ -1640,11 +1640,11 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     @trace
     @expression
-    def rename(self, column_mapper: Dict[str, str]):
-        self._check_columns(column_mapper.keys())
+    def rename(self, mapper: Dict[str, str]):
+        self._check_columns(mapper.keys())
         return self._fromdata(
             {
-                column_mapper.get(
+                mapper.get(
                     self.dtype.fields[i].name, self.dtype.fields[i].name
                 ): ColumnFromVelox._from_velox(
                     self.device,
@@ -1660,9 +1660,6 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
     @trace
     @expression
     def reorder(self, columns: List[str]):
-        """
-        Returns DataFrame with the columns in the prescribed order.
-        """
         self._check_columns(columns)
         return self._fromdata(
             {


### PR DESCRIPTION
Summary:
1. Move `get_column` and `get_columns` as private -- Pandas doens't support it, and it can be easily supported by `df[]`
2. Move `slice_column` as private and remove support for syntax like `df["a":]`:
    * Pandas doesn't support `df["a":]`
```python
>>> df2 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
>>> df2["b":]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/frame.py", line 3430, in __getitem__
    indexer = convert_to_index_sliceable(self, key)
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexing.py", line 2329, in convert_to_index_sliceable
    return idx._convert_slice_indexer(key, kind="getitem")
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexes/numeric.py", line 244, in _convert_slice_indexer
    return super()._convert_slice_indexer(key, kind=kind)
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexes/base.py", line 3719, in _convert_slice_indexer
    self._validate_indexer("slice", key.start, "getitem")
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexes/base.py", line 5719, in _validate_indexer
    raise self._invalid_indexer(form, key)
TypeError: cannot do slice indexing on RangeIndex with these indexers [b] of type str
>>> df2["b":"c"]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/frame.py", line 3430, in __getitem__
    indexer = convert_to_index_sliceable(self, key)
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexing.py", line 2329, in convert_to_index_sliceable
    return idx._convert_slice_indexer(key, kind="getitem")
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexes/numeric.py", line 244, in _convert_slice_indexer
    return super()._convert_slice_indexer(key, kind=kind)
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexes/base.py", line 3719, in _convert_slice_indexer
    self._validate_indexer("slice", key.start, "getitem")
  File "/Users/wxie/opt/miniconda3/envs/torcharrow/lib/python3.7/site-packages/pandas-1.3.4-py3.7-macosx-10.9-x86_64.egg/pandas/core/indexes/base.py", line 5719, in _validate_indexer
    raise self._invalid_indexer(form, key)
TypeError: cannot do slice indexing on RangeIndex with these indexers [b] of type str
```
   * NOTE: Pandas indeed support slicing by column name by using `iloc`: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#different-choices-for-indexing (but TorchArrow doesn't support `iloc`). So it might still be valid to support some kind of slicing by column name in the future.

Differential Revision: D33341932

