### PR TITLE
fix null values in `keys` and `values` of `MapColumn`

### DIFF
--- a/torcharrow/test/test_map_column.py
+++ b/torcharrow/test/test_map_column.py
@@ -52,8 +52,8 @@ class TestMapColumn(unittest.TestCase):
     def base_test_keys_values_get(self):
         c = ta.Column([{"abc": 123}, {"de": 45, "fg": 67}, None], device=self.device)
 
-        self.assertEqual(list(c.maps.keys()), [["abc"], ["de", "fg"], []])
-        self.assertEqual(list(c.maps.values()), [[123], [45, 67], []])
+        self.assertEqual(list(c.maps.keys()), [["abc"], ["de", "fg"], None])
+        self.assertEqual(list(c.maps.values()), [[123], [45, 67], None])
         self.assertEqual(list(c.maps.get("de", 0)), [0, 45, None])
 
 

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -12,7 +12,7 @@ import torcharrow.dtypes as dt
 import torcharrow.pytorch as pytorch
 from tabulate import tabulate
 from torcharrow.dispatcher import Dispatcher
-from torcharrow.dispatcher import Dispatcher
+from torcharrow.functional import functional
 from torcharrow.icolumn import IColumn
 from torcharrow.imap_column import IMapColumn, IMapMethods
 from torcharrow.scope import Scope
@@ -212,13 +212,11 @@ class MapMethodsCpu(IMapMethods):
         super().__init__(parent)
 
     def keys(self):
+        # Delegate to `map_keys` function
         me = self._parent
-        return ColumnFromVelox._from_velox(
-            me.device, dt.List(me._dtype.key_dtype), me._data.keys(), True
-        )
+        return functional.map_keys(me)._with_null(me._dtype.nullable)
 
     def values(self):
+        # Delegate to `map_values` function
         me = self._parent
-        return ColumnFromVelox._from_velox(
-            me.device, dt.List(me._dtype.item_dtype), me._data.values(), True
-        )
+        return functional.map_values(me)._with_null(me._dtype.nullable)


### PR DESCRIPTION
Summary:
`keys()` and `values()` in a null map should return `None` instead of empty list.
This diff delegates  `keys()` and `values()` in `MapColumn` to corresponding functions in velox

Reviewed By: OswinC

Differential Revision: D33341664

