### PR TITLE
Make StringColumn.str pattern matching API compatible with Pandas

### DIFF
--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -1036,7 +1036,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     @expression
     def isin(self, values: ty.Union[list, dict]):
         """
-        Check whether values are contained in column.
+        Check whether each element in the column is contained in values.
 
         Parameters
         ----------
@@ -1045,8 +1045,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
 
         Returns
         -------
-        Boolean column of the same length as self where item x denotes if
-        member x has a value contained in values.
+        Column of booleans indicating if each element is in values.
 
         Examples
         --------
@@ -1247,7 +1246,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     @expression
     def sum(self):
         """
-        Return sum of all non-null elements.
+        Return the sum of the non-null values.
 
         Examples
         --------
@@ -1265,14 +1264,14 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     def mean(self):
         self._check(dt.is_numerical, "mean")
         """
-        Return the mean of the non-null values in the series.
+        Return the mean of the non-null values.
 
         Examples
         --------
         >>> import torcharrow as ta
-        >>> s = ta.Column([1,2,None,4])
-        >>> s.mean(fill_value=999)
-        251.5
+        >>> s = ta.Column([1,2,None,6])
+        >>> s.mean()
+        3.0
         """
         import pyarrow.compute as pc
 
@@ -1327,7 +1326,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
     @trace
     @expression
     def any(self):
-        """Return whether any non-null element is True in Column"""
+        """Return whether any non-null element is True"""
         self._prototype_support_warning("any")
         return any(self._data_iter())
 
@@ -1409,7 +1408,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
 
     @trace
     def to_pandas(self):
-        """Convert self to pandas dataframe"""
+        """Convert self to Pandas Series"""
         import pandas as pd  # type: ignore
 
         # default implementation, normally this should be zero copy...
@@ -1418,7 +1417,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
 
     @trace
     def to_arrow(self):
-        """Convert self to pandas dataframe"""
+        """Convert self to arrow array"""
         import pyarrow as pa  # type: ignore
 
         # default implementation, normally this should be zero copy...

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -327,9 +327,9 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                 raise TypeError(
                     f"slice arguments {[type(a) for a in args]} should all be int or string"
                 )
-        elif isinstance(arg, (tuple, list)):
+        elif isinstance(arg, list):
             if len(arg) == 0:
-                return self
+                return ta.DataFrame(device=self.device)
             if all(isinstance(a, bool) for a in arg):
                 return self.filter(arg)
             if all(isinstance(a, int) for a in arg):

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -309,7 +309,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
         if isinstance(arg, int):
             return self._get(arg)
         elif isinstance(arg, str):
-            return self.get_column(arg)
+            return self._get_column(arg)
         elif isinstance(arg, slice):
             args = []
             for i in [arg.start, arg.stop, arg.step]:
@@ -319,13 +319,9 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                     args.append(i)
             if all(a is None or isinstance(a, int) for a in args):
                 return self._slice(*args)
-            elif all(a is None or isinstance(a, str) for a in args):
-                if arg.step is not None:
-                    raise TypeError(f"column slice can't have step argument {arg.step}")
-                return self.slice_columns(arg.start, arg.stop)
             else:
                 raise TypeError(
-                    f"slice arguments {[type(a) for a in args]} should all be int or string"
+                    f"slice arguments {[type(a) for a in args]} should all be int"
                 )
         elif isinstance(arg, list):
             if len(arg) == 0:
@@ -335,7 +331,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             if all(isinstance(a, int) for a in arg):
                 return self._gets(arg)
             if all(isinstance(a, str) for a in arg):
-                return self.get_columns(arg)
+                return self._get_columns(arg)
             else:
                 raise TypeError("index should be list of int or list of str")
         elif isinstance(arg, IColumn) and dt.is_boolean(arg.dtype):

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -210,6 +210,145 @@ class IDataFrame(IColumn):
 
     @trace
     @expression
+    def isin(self, values: Union[list, dict, IColumn]):
+        """
+        Check whether each element in the dataframe is contained in values.
+
+        Parameters
+        ----------
+        values - array-like, column or dict
+            Which values to check the presence of.
+
+        Returns
+        -------
+        DataFrame of booleans showing whether each element is contained in values.
+
+        Examples
+        --------
+        >>> import torcharrow as ta
+        >>> df = ta.DataFrame({"a": [1, 2, 3],
+                              "b": [4, 5, 6]
+                              })
+        >>> df.isin([1, 2, 5])
+          index  a      b
+        -------  -----  -----
+            0  True   False
+            1  True   True
+            2  False  False
+        dtype: Struct([Field('a', boolean), Field('b', boolean)]), count: 3, null_count: 0
+        """
+        raise self._not_supported("isin")
+
+    # aggregation
+
+    @trace
+    @expression
+    def min(self):
+        """
+        Return the minimum of the non-null values for each column.
+
+        Examples
+        --------
+        >>> import torcharrow as ta
+        >>> df = ta.DataFrame({"a": [1,2,None,4],
+                                "b": [5, 6, None, 8]
+                                })
+        >>> df.min()
+        index    a    b
+        -------  ---  ---
+            0    1    5
+        dtype: Struct([Field('a', Int64(nullable=True)), Field('b', Int64(nullable=True))]), count: 1, null_count: 0
+        """
+        raise self._not_supported("min")
+
+    @trace
+    @expression
+    def max(self):
+        """
+        Return the maximal of the non-null values for each column.
+
+        Examples
+        --------
+        >>> import torcharrow as ta
+        >>> df = ta.DataFrame({"a": [1,2,None,4],
+                                "b": [5, 6, None, 8]
+                                })
+        >>> df.max()
+        index    a    b
+        -------  ---  ---
+            0    4    8
+        dtype: Struct([Field('a', Int64(nullable=True)), Field('b', Int64(nullable=True))]), count: 1, null_count: 0
+        """
+        raise self._not_supported("max")
+
+    @trace
+    @expression
+    def sum(self):
+        """
+        Return the sum of the non-null values for each column.
+
+        Examples
+        --------
+        >>> import torcharrow as ta
+        >>> df = ta.DataFrame({"a": [1,2,None,4],
+                                "b": [5, 6, None, 8]
+                                })
+        >>> df.sum()
+        index    a    b
+        -------  ---  ---
+            0    7    19
+        dtype: Struct([Field('a', Int64(nullable=True)), Field('b', Int64(nullable=True))]), count: 1, null_count: 0
+        """
+        raise self._not_supported("sum")
+
+    @trace
+    @expression
+    def mean(self):
+        """
+        Return the mean of the non-null values for each column.
+
+        Examples
+        --------
+        >>> import torcharrow as ta
+        >>> df = ta.DataFrame({"a": [1.0,2.0,None,6.3],
+                                "b": [5.0, 6.0, None, 10.6]
+                                })
+        >>> df.mean()
+        index    a    b
+        -------  ---  ---
+            0  3.1  7.2
+        dtype: Struct([Field('a', Float32(nullable=True)), Field('b', Float32(nullable=True))]), count: 1, null_count: 0
+        """
+        raise self._not_supported("mean")
+
+    @trace
+    @expression
+    def std(self):
+        raise self._not_supported("std")
+
+    @trace
+    @expression
+    def median(self):
+        raise self._not_supported("median")
+
+    @trace
+    @expression
+    def mode(self):
+        raise self._not_supported("mode")
+
+    @trace
+    @expression
+    def all(self):
+        raise self._not_supported("all")
+
+    @trace
+    @expression
+    def any(self):
+        raise self._not_supported("any")
+
+    # column alnternating
+    @trace
+    @expression
     def drop(self, columns: List[str]):
         """
         Returns DataFrame without the removed columns.
@@ -233,6 +372,8 @@ class IDataFrame(IColumn):
         Returns DataFrame with the columns in the prescribed order.
         """
         raise self._not_supported("rename")
+
+    # functional API
 
     @trace
     @expression
@@ -274,6 +415,18 @@ class IDataFrame(IColumn):
             )
         return self._format_transform_result(raw_res, format, dtype, len(self))
 
+    # interop
+
+    @trace
+    def to_pandas(self):
+        """Convert self to Pandas DataFrame"""
+        raise self._not_supported("to_pandas")
+
+    @trace
+    def to_arrow(self):
+        """Convert self to arrow table"""
+        raise self._not_supported("to_arrow")
+
     @trace
     def to_pylist(self):
         tup_type = self._dtype.py_type
@@ -281,6 +434,10 @@ class IDataFrame(IColumn):
             tup_type(*v)
             for v in zip(*(self[f.name].to_pylist() for f in self._dtype.fields))
         ]
+
+    @trace
+    def to_tensor(self, conversion=None):
+        raise self._not_supported("to_tensor")
 
     def _get_column(self, column):
         """Return the named column"""

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     Iterable,
     List,
+    Dict,
     Mapping,
     Optional,
     Sequence,
@@ -208,11 +209,30 @@ class IDataFrame(IColumn):
         raise self._not_supported("copy")
 
     @trace
+    @expression
     def drop(self, columns: List[str]):
         """
         Returns DataFrame without the removed columns.
         """
         raise self._not_supported("drop")
+
+    @trace
+    @expression
+    def rename(self, mapper: Dict[str, str]):
+        """
+        Returns DataFrame with column names remapped.
+        """
+        raise self._not_supported("rename")
+
+    @trace
+    @expression
+    def reorder(self, columns: List[str]):
+        """
+        EXPERIMENTAL API
+
+        Returns DataFrame with the columns in the prescribed order.
+        """
+        raise self._not_supported("rename")
 
     @trace
     @expression

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -274,18 +274,6 @@ class IDataFrame(IColumn):
             )
         return self._format_transform_result(raw_res, format, dtype, len(self))
 
-    def get_column(self, column):
-        """Return the named column"""
-        raise self._not_supported("get_column")
-
-    def get_columns(self, columns):
-        """Return a new dataframe referencing the columns[s1],..,column[sm]"""
-        raise self._not_supported("get_columns")
-
-    def slice_columns(self, start, stop):
-        """Return a new dataframe with the slice rows[start:stop]"""
-        raise self._not_supported("slice_columns")
-
     @trace
     def to_pylist(self):
         tup_type = self._dtype.py_type
@@ -293,6 +281,18 @@ class IDataFrame(IColumn):
             tup_type(*v)
             for v in zip(*(self[f.name].to_pylist() for f in self._dtype.fields))
         ]
+
+    def _get_column(self, column):
+        """Return the named column"""
+        raise self._not_supported("get_column")
+
+    def _get_columns(self, columns):
+        """Return a new dataframe referencing the columns[s1],..,column[sm]"""
+        raise self._not_supported("get_columns")
+
+    def _slice_columns(self, start, stop):
+        """Return a new dataframe with the slice rows[start:stop]"""
+        raise self._not_supported("slice_columns")
 
 
 # TODO Make this abstract and add all the abstract methods here ...

--- a/torcharrow/istring_column.py
+++ b/torcharrow/istring_column.py
@@ -1,13 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import abc
 
-# TODO: use re2
-import re
-
-import numpy.ma as ma
 import torcharrow.dtypes as dt
 
-from .expression import expression
 from .icolumn import IColumn
 
 # ------------------------------------------------------------------------------
@@ -45,14 +40,15 @@ class IStringMethods(abc.ABC):
 
         return self._vectorize_string(func)
 
-    def split(self, sep=None):
+    def split(self, pat=None):
         """
         Split strings around given separator/delimiter.
 
         Parameters
         ----------
-        sep - str, default None
-            String literal to split on.  When None split according to whitespace.
+        pat - str, default None
+            String literal to split on, does not yet support regular expressions.
+            When None split according to whitespace.
 
         See Also
         --------
@@ -62,19 +58,13 @@ class IStringMethods(abc.ABC):
         --------
         >>> import torcharrow as ta
         >>> s = ta.Column(['what a wonderful world!', 'really?'])
-        >>> s.str.split(sep=' ')
+        >>> s.str.split(pat=' ')
         0  ['what', 'a', 'wonderful', 'world!']
         1  ['really?']
         dtype: List(string), length: 2, null_count: 0
 
         """
-        self._parent._prototype_support_warning("str.split")
-        me = self._parent
-
-        def fun(i):
-            return i.split(sep)
-
-        return self._vectorize_list_string(fun)
+        self._not_supported("split")
 
     def strip(self):
         """
@@ -161,80 +151,33 @@ class IStringMethods(abc.ABC):
 
         return self._vectorize_boolean(pred)
 
+    def count(self, pat: str):
+        """Count occurrences of pattern in each string of column"""
+        # TODO: caculating the count without materializing all the occurance?
+        return self.findall(pat).list.length()
+
     def find(self, sub):
-        self._parent._prototype_support_warning("str.find")
+        self._not_supported("find")
 
-        def fun(i):
-            return i.find(sub)
-
-        return self._vectorize_int64(fun)
-
-    def replace(self, old, new):
+    def replace(self, pat: str, repl: str, regex: bool = True):
         """
         Replace each occurrence of pattern in the Column.
         """
-        self._parent._prototype_support_warning("str.replace")
+        self._not_supported("replace")
 
-        return self._vectorize_string(lambda s: s.replace(old, new))
+    def match(self, pat: str):
+        """Determine if each string matches a regular expression"""
+        self._not_supported("match")
 
-    # Regular expressions -----------------------------------------------------
-    #
-    # Only allow string type for pattern input so it can be dispatch to other runtime (Velox, cuDF, etc)
-
-    def count_re(self, pattern: str):
-        """Count occurrences of pattern in each string"""
-        self._parent._prototype_support_warning("str.count_re")
-
-        return self.findall_re(pattern).list.length()
-
-    def match_re(self, pattern: str):
-        """Determine if each string matches a regular expression (see re.match())"""
-        self._parent._prototype_support_warning("str.match_re")
-
-        pattern = re.compile(pattern)
-
-        def func(text):
-            return True if pattern.match(text) else False
-
-        return self._vectorize_boolean(func)
-
-    def replace_re(self, pattern: str, repl: str, count=0):
-        """Replace for each item the search string or pattern with the given value"""
-        self._parent._prototype_support_warning("str.replace_re")
-
-        pattern = re.compile(pattern)
-
-        def func(text):
-            return re.sub(pattern, repl, text, count)
-
-        return self._vectorize_string(func)
-
-    def contains_re(
-        self,
-        pattern: str,
-    ):
+    def contains(self, pat: str, regex: bool = True):
         """Test for each item if pattern is contained within a string; returns a boolean"""
-        self._parent._prototype_support_warning("str.contains_re")
+        self._not_supported("contains")
 
-        pattern = re.compile(pattern)
-
-        def func(text):
-            return pattern.search(text) is not None
-
-        return self._vectorize_boolean(func)
-
-    def findall_re(self, pattern: str):
+    def findall(self, pat: str):
         """
         Find for each item all occurrences of pattern (see re.findall())
         """
-        self._parent._prototype_support_warning("str.findall_re")
-
-        pattern = re.compile(pattern)
-
-        def func(text):
-            return pattern.findall(text)
-
-        return self._vectorize_list_string(func)
+        self._not_supported("findall")
 
     # helper -----------------------------------------------------
 

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -102,10 +102,10 @@ class TestDataFrame(unittest.TestCase):
         numpy.testing.assert_almost_equal(list(df[["a", "c"]]["c"]), [1.1, 2.2, 3.3])
 
         # slice
-
-        self.assertEqual(df[:"b"].columns, ["a"])
-        self.assertEqual(df["b":].columns, ["b", "c"])
-        self.assertEqual(df["a":"c"].columns, ["a", "b"])
+        # TODO: shall we support slice via column name?
+        # self.assertEqual(df[:"b"].columns, ["a"])
+        # self.assertEqual(df["b":].columns, ["b", "c"])
+        # self.assertEqual(df["a":"c"].columns, ["a", "b"])
 
     def base_test_construction(self):
         # Column type is List of Struct

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -742,8 +742,8 @@ class TestDataFrame(unittest.TestCase):
         self.assertEqual(list(df.drop([])), [(1, 11, 111), (2, 22, 222), (3, 33, 333)])
         self.assertEqual(list(df.drop(["c", "a"])), [(11,), (22,), (33,)])
 
-        self.assertEqual(list(df.keep([])), [])
-        self.assertEqual(list(df.keep(["c", "a"])), [(1, 111), (2, 222), (3, 333)])
+        self.assertEqual(list(df[[]]), [])
+        self.assertEqual(list(df[["a", "c"]]), [(1, 111), (2, 222), (3, 333)])
 
         self.assertEqual(
             list(df.rename({"a": "c", "c": "a"})),
@@ -784,7 +784,11 @@ class TestDataFrame(unittest.TestCase):
 
         self.assertEqual(list(df.select("*")), list(df))
 
-        self.assertEqual(list(df.select("a")), list(df.keep(["a"])))
+        self.assertEqual(list(df.select("a")), list(df[["a"]]))
+        self.assertEqual(list(df.select("a", "b")), list(df[["a", "b"]]))
+        # df.select("b", "a") will keep the original column ordering ("a, b"),
+        #   is this the expected behavior?
+        self.assertEqual(list(df.select(b=me["b"], a=me["a"])), list(df[["b", "a"]]))
         self.assertEqual(list(df.select("*", "-a")), list(df.drop(["a"])))
 
         gf = ta.DataFrame(

--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -176,7 +176,11 @@ class TestStringColumn(unittest.TestCase):
         )
 
         self.assertEqual(
-            list(ta.Column(s, device=self.device).str.replace("this", "that")),
+            list(
+                ta.Column(s, device=self.device).str.replace(
+                    "this", "that", regex=False
+                )
+            ),
             [v.replace("this", "that") for v in s],
         )
 
@@ -194,34 +198,35 @@ class TestStringColumn(unittest.TestCase):
             device=self.device,
         )
         # count
-        self.assertEqual(
-            list(S[S.str.count_re(r"(^F.*)") == 1]), ["Finland", "Florida"]
-        )
-        self.assertEqual(S.str.count_re(r"(^F.*)").sum(), 2)
+        self.assertEqual(list(S[S.str.count(r"(^F.*)") == 1]), ["Finland", "Florida"])
+        self.assertEqual(S.str.count(r"(^F.*)").sum(), 2)
         # match
-        self.assertEqual(list(S[S.str.match_re(r"(^P.*)") == True]), ["Puerto Rico"])
+        self.assertEqual(list(S[S.str.match(r"(^P.*)") == True]), ["Puerto Rico"])
+
         # replace
-        self.assertEqual(
-            list(S.str.replace_re("(-d)", "")),
-            [
-                "Finland",
-                "Colombia",
-                "Florida",
-                "Japan",
-                "Puerto Rico",
-                "Russia",
-                "france",
-            ],
-        )
+        # TODO: support replace with regex
+        # self.assertEqual(
+        #    list(S.str.replace("(-d)", "")),
+        #    [
+        #        "Finland",
+        #        "Colombia",
+        #        "Florida",
+        #        "Japan",
+        #        "Puerto Rico",
+        #        "Russia",
+        #        "france",
+        #    ],
+        # )
+
         # contains
         self.assertEqual(
-            list(S.str.contains_re("^F.*")),
+            list(S.str.contains("^F.*")),
             [True, False, True, False, False, False, False],
         )
 
         # findall (creates a list), we select the non empty ones.
 
-        l = S.str.findall_re("^[Ff].*")
+        l = S.str.findall("^[Ff].*")
         self.assertEqual(
             list(l[l.list.length() > 0]),
             [
@@ -232,7 +237,7 @@ class TestStringColumn(unittest.TestCase):
         )
 
         # extract all
-        l = S.str.findall_re("^[Ff](.*)")
+        l = S.str.findall("^[Ff](.*)")
         self.assertEqual(
             list(l[l.list.length() > 0]),
             [
@@ -242,7 +247,7 @@ class TestStringColumn(unittest.TestCase):
             ],
         )
 
-        l = S.str.findall_re("[tCc]o")
+        l = S.str.findall("[tCc]o")
         self.assertEqual(
             list(l[l.list.length() > 0]),
             [

--- a/torcharrow/test/test_trace.py
+++ b/torcharrow/test/test_trace.py
@@ -228,7 +228,7 @@ class TestDataframeTrace(unittest.TestCase):
         df["d"] = c1
 
         d1 = df.drop(["a"])
-        d2 = df.keep(["a", "c"])
+        d2 = df[["a", "c"]]
         # TODO Clarify: Why did we have in 0.2 this as an  self.assertRaises(AttributeError):
         # AttributeError: cannot override existing column d
         # simply overrides the column name, but that's ok...
@@ -246,7 +246,7 @@ class TestDataframeTrace(unittest.TestCase):
         df["d"] = c1
 
         d1 = df.drop(["a"])
-        d2 = df.keep(["a", "c"])
+        d2 = df[["a", "c"]]
         d3 = d2.rename({"c": "e"})
 
         d4 = d3.min()
@@ -260,7 +260,7 @@ class TestDataframeTrace(unittest.TestCase):
             "c4 = torcharrow.icolumn.IColumn.__getitem__(c0, 'a')",
             "_ = torcharrow.idataframe.IDataFrame.__setitem__(c0, 'd', c4)",
             "c11 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.drop(c0, ['a'])",
-            "c16 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.keep(c0, ['a', 'c'])",
+            "c16 = torcharrow.icolumn.IColumn.__getitem__(c0, ['a', 'c'])",
             "c21 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.rename(c16, {'c': 'e'})",
             "c24 = torcharrow.velox_rt.dataframe_cpu.DataFrameCpu.min(c21)",
         ]

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -305,7 +305,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             mask,
         )
 
-    def get_column(self, column):
+    def _get_column(self, column):
         idx = self._data.type().get_child_idx(column)
         return ColumnFromVelox._from_velox(
             self.device,
@@ -314,14 +314,14 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
             True,
         )
 
-    def get_columns(self, columns):
+    def _get_columns(self, columns):
         # TODO: decide on nulls, here we assume all defined (mask = False) for new parent...
         res = {}
         for n in columns:
-            res[n] = self.get_column(n)
+            res[n] = self._get_column(n)
         return self._fromdata(res, self._mask)
 
-    def slice_columns(self, start, stop):
+    def _slice_columns(self, start, stop):
         # TODO: decide on nulls, here we assume all defined (mask = False) for new parent...
         _start = 0 if start is None else self._column_index(start)
         _stop = len(self.columns) if stop is None else self._column_index(stop)

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -1619,7 +1619,7 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     @trace
     @expression
-    def keep(self, columns: List[str]):
+    def _keep(self, columns: List[str]):
         """
         Returns DataFrame with the kept columns only.
         """
@@ -1640,11 +1640,11 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
 
     @trace
     @expression
-    def rename(self, column_mapper: Dict[str, str]):
-        self._check_columns(column_mapper.keys())
+    def rename(self, mapper: Dict[str, str]):
+        self._check_columns(mapper.keys())
         return self._fromdata(
             {
-                column_mapper.get(
+                mapper.get(
                     self.dtype.fields[i].name, self.dtype.fields[i].name
                 ): ColumnFromVelox._from_velox(
                     self.device,
@@ -1660,9 +1660,6 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
     @trace
     @expression
     def reorder(self, columns: List[str]):
-        """
-        Returns DataFrame with the columns in the prescribed order.
-        """
         self._check_columns(columns)
         return self._fromdata(
             {

--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -1023,41 +1023,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "3fb1ab56-d921-4601-a936-fb42008c4fbb"
-      },
-      "source": [
-        "But you can also slice columns. The below return all columns after and including 'c'."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "63b11653-9ab3-43c2-800b-3fa2de2367c7",
-        "collapsed": false,
-        "requestMsgId": "74e562f4-0c75-4453-93c0-1b206a9de830",
-        "executionStartTime": 1634146946931,
-        "executionStopTime": 1634146947071
-      },
-      "source": [
-        "df['c':]"
-      ],
-      "execution_count": 23,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "  index    c     d\n-------  ---  ----\n      0   12    99\n      1   10   100\n      2    8   101\n      3    6   102\n      4    4   103\n      5    2   104\n      6    0   105\n      7  777  7777\n      8  888  8888\ndtype: Struct([Field('c', int64), Field('d', int64)]), count: 9, null_count: 0"
-          },
-          "metadata": {
-            "bento_obj_id": "139832115497856"
-          },
-          "execution_count": 23
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "originalKey": "39596721-fafa-4afe-8e30-adebc69d41e7",
         "showInput": false,
         "code_folding": [],

--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -1494,7 +1494,7 @@
         "executionStopTime": 1634146948979
       },
       "source": [
-        "ss = s.str.split(sep=\" \")\n",
+        "ss = s.str.split(pat=\" \")\n",
         "ss\n",
         ""
       ],


### PR DESCRIPTION
Summary:
Previously TorchArrow use "XXX" and "XXX_re" to distinguish between regex and non-regex (e.g. `match_re`, `replace`)

Pandas use `regex` flag to distinguish them.

Also some parameter name change to be compatible with Pandas.

Differential Revision: D33354746

