### PR TITLE
Support maxsplit in IStringColumn.str.split

### DIFF
--- a/torcharrow/istring_column.py
+++ b/torcharrow/istring_column.py
@@ -40,7 +40,7 @@ class IStringMethods(abc.ABC):
 
         return self._vectorize_string(func)
 
-    def split(self, pat=None):
+    def split(self, pat=None, n=-1):
         """
         Split strings around given separator/delimiter.
 
@@ -49,6 +49,8 @@ class IStringMethods(abc.ABC):
         pat - str, default None
             String literal to split on, does not yet support regular expressions.
             When None split according to whitespace.
+        n - int, default -1 means no limit
+            Maximum number of splits to do. 0 will be interpreted as return all splits.
 
         See Also
         --------
@@ -60,6 +62,10 @@ class IStringMethods(abc.ABC):
         >>> s = ta.Column(['what a wonderful world!', 'really?'])
         >>> s.str.split(pat=' ')
         0  ['what', 'a', 'wonderful', 'world!']
+        1  ['really?']
+        dtype: List(string), length: 2, null_count: 0
+        >>> s.str.split(pat=' ', n=2)
+        0  ['what', 'a', 'wonderful world!']
         1  ['really?']
         dtype: List(string), length: 2, null_count: 0
 

--- a/torcharrow/test/lib_test/test_udf.py
+++ b/torcharrow/test/lib_test/test_udf.py
@@ -94,6 +94,16 @@ class TestSimpleColumns(unittest.TestCase):
         isspace = ta.generic_udf_dispatch("torcharrow_isspace", col3)
         self.assert_SimpleColumn(isspace, [True, False, True, False, True, None])
 
+        data4 = ["a b c", "d,e,f"]
+        col4 = self.construct_simple_column(ta.VeloxType_VARCHAR(), data4)
+        splits = ta.generic_udf_dispatch(
+            "split", col4, ta.ConstantColumn(" ", len(data4))
+        )
+        expected = [["a", "b", "c"], ["d,e,f"]]
+        self.assertEqual(len(splits), len(expected))
+        for i in range(len(splits)):
+            self.assert_SimpleColumn(splits[i], expected[i])
+
     def test_regex(self):
         # test some regex UDF
         data = ["abc", "a1", "b2", "c3", "___d4___", None]

--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -35,6 +35,11 @@ class TestStringColumn(unittest.TestCase):
         self.assertEqual(list(c.str.split(".")), [v.split(".") for v in s])
         self.assertEqual(list(c.str.split()), [v.split() for v in s])
         self.assertEqual(list(c.str.split(",")), [v.split(",") for v in s])
+        # with max splits
+        self.assertEqual(list(c.str.split(".", -1)), [v.split(".") for v in s])
+        self.assertEqual(list(c.str.split(".", 0)), [v.split(".") for v in s])
+        self.assertEqual(list(c.str.split(".", 2)), [v.split(".", 2) for v in s])
+        self.assertEqual(list(c.str.split(".", 10)), [v.split(".", 10) for v in s])
 
     def base_test_string_categorization_methods(self):
         # isalpha/isnumeric/isalnum/isdigit/isdecimal/isspace/islower/isupper

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -235,11 +235,13 @@ class StringMethodsCpu(IStringMethods):
                 self._parent.dtype.nullable
             )
 
-    def split(self, pat=None):
+    def split(self, pat=None, n=-1):
         pat = pat or " "
-        return functional.split(self._parent, pat)._with_null(
-            self._parent.dtype.nullable
-        )
+        if n <= 0:
+            split_result = functional.split(self._parent, pat)
+        else:
+            split_result = functional.split(self._parent, pat, n + 1)
+        return split_result._with_null(self._parent.dtype.nullable)
 
     def strip(self):
         return functional.trim(self._parent)._with_null(self._parent.dtype.nullable)


### PR DESCRIPTION
Summary:
Resolve https://github.com/facebookresearch/torcharrow/issues/30

Keep interface consistent with Pandas split API so name is n instead of maxsplit. Also 0 is treated different from python native str split.

Differential Revision: D33409095

