### PR TITLE
Raise error when calling DataFrameCpu.append() with unsupported value

### DIFF
--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -230,6 +230,12 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
                 return self.append(
                     [{f.name: v for f, v in zip(self.dtype.fields, value)}]
                 ).append(it)
+
+            else:
+                raise TypeError(
+                    f"Unexpected value type to append to DataFrame: {type(value).__name__}, the value being appended is: {value}"
+                )
+
         except StopIteration:
             return self
 


### PR DESCRIPTION
Summary:
Previously it will silently return None, to reproduce

```python
import torcharrow as ta
import torcharrow.dtypes as dt

dtype = dt.Struct(
    [
        dt.Field("labels", dt.int8),
        dt.Field("dense_features", dt.Struct([dt.Field("int_1", dt.int32), dt.Field("int_2", dt.int32)])),
    ]
)

df = ta.DataFrame(
    [
        (1, [0, 1]),     # <-- Should be (1, (0, 1))
        (0, [10, 11])
    ],
    dtype=dtype)
```

Previously it silently return None, and cause error hard to understand (`'NoneType' object has no attribute 'dtype'`), especially when  there are a lot of nested fields.

 Raise exception with more information to help developer understand the error.

Differential Revision: D33595208

