### PR TITLE
Support DataFrame.log() as well

### DIFF
--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -22,10 +22,13 @@ inline void registerTorchArrowFunctions() {
   velox::registerFunction<udf_torcharrow_isnumeric, bool, velox::Varchar>(
       {"isnumeric"});
 
+  // Natural logarithm
   velox::registerFunction<udf_torcharrow_log, float, float>({"torcharrow_log"});
   velox::registerFunction<udf_torcharrow_log, double, double>(
       {"torcharrow_log"});
   velox::registerFunction<udf_torcharrow_log, float, bool>({"torcharrow_log"});
+  // TODO: support type promotion in TorchArrow-Velox backend so registering less
+  // overloads.
   velox::registerFunction<udf_torcharrow_log, float, int8_t>(
       {"torcharrow_log"});
   velox::registerFunction<udf_torcharrow_log, float, int16_t>(

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -239,6 +239,9 @@ class IDataFrame(IColumn):
         """
         raise self._not_supported("isin")
 
+    def log(self) -> IDataFrame:
+        raise self._not_supported("log")
+
     # aggregation
 
     @trace

--- a/torcharrow/inumerical_column.py
+++ b/torcharrow/inumerical_column.py
@@ -29,4 +29,5 @@ class INumericalColumn(IColumn):
             raise AssertionError("unexpected case")
 
     def log(self):
+        """Returns a new column with the natural logarithm of the elements"""
         raise self._not_supported("log")

--- a/torcharrow/test/transformation/test_numeric_ops.py
+++ b/torcharrow/test/transformation/test_numeric_ops.py
@@ -1,14 +1,29 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+import math
 import unittest
 
+import numpy.testing
 import torcharrow as ta
+import torcharrow.dtypes as dt
+
 
 # TODO: add/migrate more numeric tests
 class _TestNumericOpsBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Prepare input data as CPU dataframe
-        cls.base_df = ta.DataFrame({"c": [0, 1, 3], "d": [5, 5, 6], "e": [1.0, 1, 7]})
+        cls.base_add_df = ta.DataFrame(
+            {"c": [0, 1, 3], "d": [5, 5, 6], "e": [1.0, 1, 7]}
+        )
+        cls.base_log_df = ta.DataFrame(
+            {
+                "int32": ta.Column([1, 0, 4, None], dtype=dt.Int32(nullable=True)),
+                "int64": ta.Column([1, 0, 4, None], dtype=dt.Float32(nullable=True)),
+                "float64": ta.Column(
+                    [1.0, 0.0, 4.0, None], dtype=dt.Float64(nullable=True)
+                ),
+            }
+        )
 
         cls.setUpTestCaseData()
 
@@ -20,18 +35,44 @@ class _TestNumericOpsBase(unittest.TestCase):
         raise unittest.SkipTest("abstract base test")
 
     def test_add(self):
-        c = type(self).df["c"]
-        d = type(self).df["d"]
+        c = type(self).add_df["c"]
+        d = type(self).add_df["d"]
 
         self.assertEqual(list(c + 1), [1, 2, 4])
         self.assertEqual(list(1 + c), [1, 2, 4])
         self.assertEqual(list(c + d), [5, 6, 9])
 
+    def test_log(self):
+        log_int32_col = type(self).log_df["int32"].log()
+        log_int64_col = type(self).log_df["int64"].log()
+        log_float64_col = type(self).log_df["float64"].log()
+        log_whole_df = type(self).log_df.log()
+
+        for col in [
+            log_int32_col,
+            log_int64_col,
+            log_whole_df["int32"],
+            log_whole_df["int64"],
+        ]:
+            numpy.testing.assert_almost_equal(
+                list(col)[:-1], [0.0, -float("inf"), math.log(4)]
+            )
+            self.assertEqual(col.dtype, dt.Float32(nullable=True))
+            self.assertEqual(list(col)[-1], None)
+
+        for col in [log_float64_col, log_whole_df["float64"]]:
+            numpy.testing.assert_almost_equal(
+                list(col)[:-1], [0.0, -float("inf"), math.log(4)]
+            )
+            self.assertEqual(col.dtype, dt.Float64(nullable=True))
+            self.assertEqual(list(col)[-1], None)
+
 
 class TestNumericOpsCpu(_TestNumericOpsBase):
     @classmethod
     def setUpTestCaseData(cls):
-        cls.df = cls.base_df.copy()
+        cls.add_df = cls.base_add_df.copy()
+        cls.log_df = cls.base_log_df.copy()
 
 
 if __name__ == "__main__":

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -230,6 +230,12 @@ class DataFrameCpu(ColumnFromVelox, IDataFrame):
                 return self.append(
                     [{f.name: v for f, v in zip(self.dtype.fields, value)}]
                 ).append(it)
+
+            else:
+                raise TypeError(
+                    f"Unexpected value type to append to DataFrame: {type(value).__name__}, the value being appended is: {value}"
+                )
+
         except StopIteration:
             return self
 


### PR DESCRIPTION
Summary:
Quite convenient in the Criteo-DLRM preproc workload (ongoing work in https://github.com/facebookresearch/torchrec/pull/2), e.g. we can do
```
df["dense_features"] = (dense_features["dense_features] + 3).log()
```
where "dense_features" is a nested struct with 13 columns.

API rational: Pandas supports limited number of numeric functions. But for numeric ops Pandas supported (e.g. `abs`, `add`), they are both applicable for Series and DataFrame:
```python
>>> import pandas as pd
>>> df = pd.DataFrame({"a": [1, 2, -3], "b": [-4, -5, 6]}

>>> df["a"].abs()
0    1
1    2
2    3
Name: a, dtype: int64
>>> df.abs()
   a  b
0  1  4
1  2  5
2  3  6
>>> df["a"].add(1)
0    2
1    3
2   -2
Name: a, dtype: int64
>>> df.add(1)
   a  b
0  2 -3
1  3 -4
2 -2  7
```

Differential Revision: D33616632

