### PR TITLE
use pybind11 primitive type converters instead of casting manually

### DIFF
--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -457,8 +457,8 @@ py::class_<SimpleColumn<T>, BaseColumn> declareIntegralType(py::module& m) {
       declareNumericalType<kind>(m)
           .def(
               "append",
-              [](SimpleColumn<T>& self, py::int_ value) {
-                self.append(py::cast<T>(value));
+              [](SimpleColumn<T>& self, T value) {
+                self.append(value);
               })
           .def("invert", &SimpleColumn<T>::invert);
   declareBitwiseOperations(pyClass);
@@ -473,13 +473,8 @@ py::class_<SimpleColumn<T>, BaseColumn> declareFloatingType(py::module& m) {
   return declareNumericalType<kind>(m)
       .def(
           "append",
-          [](SimpleColumn<T>& self, py::float_ value) {
-            self.append(py::cast<T>(value));
-          })
-      .def(
-          "append",
-          [](SimpleColumn<T>& self, py::int_ value) {
-            self.append(py::cast<T>(value));
+          [](SimpleColumn<T>& self, T value) {
+            self.append(value);
           })
       .def("ceil", &SimpleColumn<T>::ceil)
       .def("floor", &SimpleColumn<T>::floor)

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -518,11 +518,39 @@ class TestNumericalColumn(unittest.TestCase):
         self.assertEqual(col3_float64.dtype, dt.Float64(nullable=True))
         self.assertEqual(list(col3_float64), data2)
 
-    def base_test_column_from_np_array(self):
-        seq = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
-        a = np.array(seq)
-        c = ta.Column(a, device=self.device)
-        self.assertEqual(list(c), seq)
+    def base_test_column_from_numpy_array(self):
+        seq_float = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        seq_int = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        array_float32 = np.array(seq_float, dtype=np.float32)
+        column_float32 = ta.Column(array_float32, device=self.device)
+        self.assertEqual(list(column_float32), seq_float)
+
+        array_float64 = np.array(seq_float, dtype=np.float64)
+        column_float64 = ta.Column(array_float64, device=self.device)
+        self.assertEqual(list(column_float64), seq_float)
+
+        array_int32 = np.array(seq_int, dtype=np.int32)
+        column_int32 = ta.Column(array_int32, device=self.device)
+        self.assertEqual(list(column_int32), seq_int)
+
+        array_int64 = np.array(seq_int, dtype=np.int64)
+        column_int64 = ta.Column(array_int64, device=self.device)
+        self.assertEqual(list(column_int64), seq_int)
+
+    def base_test_append_automatic_conversions(self):
+        # ints ARE converted to floats
+        seq_float = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        column_float = ta.Column(seq_float, device=self.device)
+        column_float = column_float.append([11, 12])
+        self.assertEqual(list(column_float), seq_float + [11.0, 12.0])
+
+        # floats ARE NOT converted to ints
+        seq_int = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        column_int = ta.Column(seq_int, device=self.device)
+        with self.assertRaises(TypeError):
+            # TypeError: append(): incompatible function arguments.
+            column_int.append([11.0, 12.0])
 
     # experimental
     def base_test_batch_collate(self):

--- a/torcharrow/test/test_numerical_column_cpu.py
+++ b/torcharrow/test/test_numerical_column_cpu.py
@@ -60,8 +60,11 @@ class TestNumericalColumnCpu(TestNumericalColumn):
     def test_describe(self):
         return self.base_test_describe()
 
-    def test_column_from_np_array(self):
-        return self.base_test_column_from_np_array()
+    def test_column_from_numpy_array(self):
+        return self.base_test_column_from_numpy_array()
+
+    def test_append_automatic_conversions(self):
+        return self.base_test_append_automatic_conversions()
 
     def test_batch_collate(self):
         return self.base_test_batch_collate()


### PR DESCRIPTION
Summary:
Before this diff, our C++ interface used `py::int_` and `py::float_`, and then would call `py::cast<T>(val)` where `val` is either `py::int_` or `py::float_` and `T` is a primitive C++ type. This would break when we would try to provide Python types like `np.float32` or `np.int64`. A test like one of the ones this diff adds would encounter this kind of error:

```
======================================================================
ERROR: test_column_from_np_int_array (torcharrow.test.test_numerical_column_cpu.TestNumericalColumnCpu)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/users/scottas/fbsource/fbcode/buck-out/dev/gen/pytorch/torcharrow/torcharrow/test/tests#binary,link-tree/torcharrow/test/test_numerical_column_cpu.py", line 67, in test_column_from_np_int_array
    return self.base_test_column_from_np_int_array()
  File "/data/users/scottas/fbsource/fbcode/buck-out/dev/gen/pytorch/torcharrow/torcharrow/test/tests#binary,link-tree/torcharrow/test/test_numerical_column.py", line 495, in base_test_column_from_np_int_array
    c = ta.Column(a, device=self.device)
  File "/data/users/scottas/fbsource/fbcode/buck-out/dev/gen/pytorch/torcharrow/torcharrow/test/tests#binary,link-tree/torcharrow/icolumn.py", line 88, in Column
    return Scope._Column(data, dtype=dtype, device=device)
  File "/data/users/scottas/fbsource/fbcode/buck-out/dev/gen/pytorch/torcharrow/torcharrow/test/tests#binary,link-tree/torcharrow/trace.py", line 98, in wrapped
    res = fn(*args, **kwargs)
  File "/data/users/scottas/fbsource/fbcode/buck-out/dev/gen/pytorch/torcharrow/torcharrow/test/tests#binary,link-tree/torcharrow/scope.py", line 221, in _Column
    col._append(p)
  File "/data/users/scottas/fbsource/fbcode/buck-out/dev/gen/pytorch/torcharrow/torcharrow/test/tests#binary,link-tree/torcharrow/trace.py", line 98, in wrapped
    res = fn(*args, **kwargs)
  File "/data/users/scottas/fbsource/fbcode/buck-out/dev/gen/pytorch/torcharrow/torcharrow/test/tests#binary,link-tree/torcharrow/icolumn.py", line 1532, in _append
    self._append_value(value)
  File "/data/users/scottas/fbsource/fbcode/buck-out/dev/gen/pytorch/torcharrow/torcharrow/test/tests#binary,link-tree/torcharrow/velox_rt/numerical_column_cpu.py", line 88, in _append_value
    self._data.append(value)
TypeError: append(): incompatible function arguments. The following argument types are supported:
    1. (self: torcharrow._torcharrow.SimpleColumnBIGINT, arg0: int) -> None

Invoked with: <torcharrow._torcharrow.SimpleColumnBIGINT object at 0x7f5bdf7e43f0>, 1

----------------------------------------------------------------------
```
What's notable here is that the type we're trying to append is a `np.int64`. The error above is saying that append `arg0` should be `int`, but we have an object. That is, there's no conversion from `np.int64` to `int`. In the docs, pybind11 mentions [three options for defining these interfaces](https://pybind11.readthedocs.io/en/stable/advanced/cast/index.html). The third option is using C++ native types on the C++ side, and Python native types on the Python side, and depending on pybind11 to perform the type conversion. There are type conversions [already defined for numpy](https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html). For primitive types, I think this approach is simplest.

The pybind11 docs mention automatic conversions for the numpy primitive types to the C++ primitive types, but we're not able to take advantage of it since our C++ interface does not use the C++ primitives.

This diff changes our C++ interface so that it does use the C++ primitive types, and then we're able to take advantage of the automatic conversion.

Reviewed By: wenleix

Differential Revision: D33300430

