### PR TITLE
use pybind11 primitive type converter for bools

### DIFF
--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -742,17 +742,22 @@ PYBIND11_MODULE(_torcharrow, m) {
   declareIntegralType<velox::TypeKind::SMALLINT>(m);
   declareIntegralType<velox::TypeKind::TINYINT>(m);
 
+  using BIGINTNativeType = velox::TypeTraits<velox::TypeKind::BIGINT>::NativeType;
   auto boolColumnClass = declareSimpleType<velox::TypeKind::BOOLEAN>(
                              m, [](auto val) { return py::cast(val); })
                              .def(
                                  "append",
-                                 [](SimpleColumn<bool>& self, py::bool_ value) {
-                                   self.append(py::cast<bool>(value));
-                                 })
+                                 [](SimpleColumn<bool>& self, bool value) {
+                                   self.append(value);
+                                 },
+                                 // explicitly disallow all conversions to bools; enabling
+                                 // this allows `None` and floats to convert to bools
+                                 py::arg("value").noconvert()
+                                 )
                              .def(
                                  "append",
-                                 [](SimpleColumn<bool>& self, py::int_ value) {
-                                   self.append(py::cast<bool>(value));
+                                 [](SimpleColumn<bool>& self, BIGINTNativeType value) {
+                                   self.append(static_cast<bool>(value));
                                  })
                              .def("invert", &SimpleColumn<bool>::invert);
   declareComparisons(boolColumnClass);

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -521,6 +521,7 @@ class TestNumericalColumn(unittest.TestCase):
     def base_test_column_from_numpy_array(self):
         seq_float = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
         seq_int = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        seq_bool = [True, False, True, False, False, False, True, True, False]
 
         array_float32 = np.array(seq_float, dtype=np.float32)
         column_float32 = ta.Column(array_float32, device=self.device)
@@ -538,6 +539,10 @@ class TestNumericalColumn(unittest.TestCase):
         column_int64 = ta.Column(array_int64, device=self.device)
         self.assertEqual(list(column_int64), seq_int)
 
+        array_bool = np.array(seq_bool, dtype=np.bool)
+        column_bool = ta.Column(array_bool, device=self.device)
+        self.assertEquals(list(column_bool), seq_bool)
+
     def base_test_append_automatic_conversions(self):
         # ints ARE converted to floats
         seq_float = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
@@ -551,6 +556,18 @@ class TestNumericalColumn(unittest.TestCase):
         with self.assertRaises(TypeError):
             # TypeError: append(): incompatible function arguments.
             column_int.append([11.0, 12.0])
+
+        # ints ARE converted to bools
+        seq_bool = [True, False, True, False, False, True, True]
+        column_bool = ta.Column(seq_bool, device=self.device)
+        column_bool = column_bool.append([1, 1, 0, 0])
+        self.assertEqual(list(column_bool), seq_bool + [True, True, False, False])
+
+        # floats ARE NOT converted to bools
+        column_bool = ta.Column(seq_bool, device=self.device)
+        with self.assertRaises(TypeError):
+            # TypeError: append(): incompatible function arguments.
+            column_bool = column_bool.append([1.0, 1.0, 0.0, 0.0])
 
     # experimental
     def base_test_batch_collate(self):


### PR DESCRIPTION
Summary: Following the pattern in D33300430 (https://github.com/facebookresearch/torcharrow/commit/dc486273f4add0d8fa6e18302c87c37c30d93243)/https://github.com/facebookresearch/torcharrow/pull/145, this changes the C++ interface for the bool column to use the C++ native types.

Reviewed By: wenleix

Differential Revision: D33670599

