### PR TITLE
Reinstate test_df_without_input

### DIFF
--- a/torcharrow/test/test_trace.py
+++ b/torcharrow/test/test_trace.py
@@ -366,7 +366,6 @@ class TestDataframeTrace(unittest.TestCase):
         # exec(";".join(stms))
         # self.assertEqual(list(eval(d1_result)), list(eval(d2_result)))
 
-    @unittest.skip("fix https://github.com/facebookresearch/torcharrow/issues/35")
     def test_df_without_input(self):
         d0 = ta.DataFrame(
             dtype=dt.Struct([dt.Field(i, dt.int64) for i in ["a", "b", "c"]])


### PR DESCRIPTION
Summary:
D33716916/https://github.com/facebookincubator/velox/pull/913 fixed the underlying SEGV by improving Velox API,
D33725519 updated our version of Velox to include this fix, so we can
now re-enable this test.

Reviewed By: wenleix

Differential Revision: D33725536

