### PR TITLE
Initial support for from_arrow() for struct column

### DIFF
--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -23,6 +23,9 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_from_arrow_table(self):
         return self.base_test_from_arrow_table()
 
+    def test_from_arrow_table_with_struct(self):
+        return self.base_test_from_arrow_table_with_struct()
+
     def test_from_arrow_table_with_chunked_arrays(self):
         return self.base_test_from_arrow_table_with_chunked_arrays()
 


### PR DESCRIPTION
Summary:
Similar to D33652891 (https://github.com/facebookresearch/torcharrow/commit/8be2e4531a027c3f48340abf74a5b13a57a3b7fd) /  https://github.com/facebookresearch/torcharrow/pull/155, add basic support in Python with non-optimal perf.

Once there is Arrow StructArray -> Velox RowVector conversion, we should switch to use that for better performance

Differential Revision: D33784374

