### PR TITLE
Use SIMD for counting nulls for a 2.2x speedup

### DIFF
--- a/csrc/velox/column.h
+++ b/csrc/velox/column.h
@@ -258,14 +258,9 @@ class BaseColumn {
       velox::VectorPtr veloxVector,
       velox::vector_size_t offset,
       velox::vector_size_t length) {
-    velox::vector_size_t nullCount = 0;
-    VELOX_CHECK(offset + length <= veloxVector->size());
-    for (velox::vector_size_t i = 0; i < length; i++) {
-      if (veloxVector->isNullAt(offset + i)) {
-        nullCount++;
-      }
-    }
-    return nullCount;
+    VELOX_CHECK_LE(offset + length, veloxVector->size());
+    return velox::BaseVector::countNulls(
+        veloxVector->nulls(), offset, offset + length);
   }
 
  public:


### PR DESCRIPTION
Instead of iterating and counting nulls manually, using the function provided by Velox which uses SIMD underneath. This shows a ~2.2x speedup in a simple experiment:

```python
>>> import torcharrow as ta
>>> import numpy as np
>>> import timeit
>>> 
>>> npc = np.random.rand(1_000_000)
>>> tac = ta.Column(list(npc))
>>> 
>>> def bench(f, number=100):
...     return timeit.timeit(f, number=number)
... 
```

Before:

```python
>>> bench(lambda: tac * tac)
0.9461154370219447
>>> bench(lambda: tac * tac, 1000)
8.546907951997127
```

After:

```python
>>> bench(lambda: tac * tac)
0.4310396400396712
>>> bench(lambda: tac * tac, 1000)
3.853910766018089
```