### PR TITLE
functional support dispatch to other backends

### DIFF
--- a/torcharrow/functional.py
+++ b/torcharrow/functional.py
@@ -6,31 +6,43 @@ from torcharrow.icolumn import IColumn
 
 
 class _Functional(ModuleType):
+    # In the future, TorchArrow is going to support more device/dispatch_key, such as gpu/libcudf
+    _device_to_dispatch_key = {"cpu": "velox"}
+    _column_class_to_dispatch_key = {}
+
     def __init__(self):
         super().__init__("torcharrow.functional")
         self._backend_functional: Dict[str, ModuleType] = {}
         self._factory_methods: Set[str] = set()
 
-    def get_backend_functional(self, backend):
-        backend_functional = self._backend_functional.get(backend)
+    def get_backend_functional(self, dispatch_key):
+        backend_functional = self._backend_functional.get(dispatch_key)
         if backend_functional is None:
             raise AssertionError(
-                f"Functional module for backend {backend} is not registered"
+                f"Functional module for backend {dispatch_key} is not registered"
             )
         return backend_functional
 
     # dispatch the function call based on backend
     def create_dispatch_wrapper(self, op_name: str):
         def dispatch(*args):
-            device = next(
-                (arg.device for arg in args if isinstance(arg, IColumn)), None
+            # Caculate dispatch key based on input
+            col_arg: IColumn = next(
+                (arg for arg in args if isinstance(arg, IColumn)), None
             )
-            if device is None:
+
+            if col_arg is None:
+                # TODO: suppoort this to return a constant literal
                 raise ValueError("None of the argument is Column")
-            backend = _Functional.device_to_backend[device]
+
+            if type(col_arg) in type(self)._column_class_to_dispatch_key:
+                dispatch_key = type(self)._column_class_to_dispatch_key[type(col_arg)]
+            else:
+                device = col_arg.device
+                dispatch_key = _Functional._device_to_dispatch_key.get(device)
 
             # dispatch to backend functional namespace
-            op = self.get_backend_functional(backend).__getattr__(op_name)
+            op = self.get_backend_functional(dispatch_key).__getattr__(op_name)
             return op(*args)
 
         def factory_dispatch(*args, size=None, device="cpu"):
@@ -41,13 +53,13 @@ class _Functional(ModuleType):
 
             # We assume that other args for factory functions are non-columns and don't even check args
             if isinstance(size, int):
-                backend = _Functional.device_to_backend[device]
+                dispatch_key = _Functional._device_to_dispatch_key[device]
             else:
                 # TODO: Support SizeProxy
                 raise AssertionError(f"Unsupported size parameter type {type(size)}")
 
             # dispatch to backend functional namespace
-            op = self.get_backend_functional(backend).__getattr__(op_name)
+            op = self.get_backend_functional(dispatch_key).__getattr__(op_name)
             return op(*args, size=size, device=device)
 
         if op_name in self._factory_methods:
@@ -62,6 +74,14 @@ class _Functional(ModuleType):
             )
         self._backend_functional[name] = module
 
+    @classmethod
+    def register_column_class_for_dispatch(cls, column_class: type, dispatch_key: str):
+        if column_class in cls._column_class_to_dispatch_key:
+            raise AssertionError(
+                f"Column class {column_class} is already registered with dispatch key {dispatch_key}"
+            )
+        cls._column_class_to_dispatch_key[column_class] = dispatch_key
+
     # TODO: Perhaps this should be part of dispatch backend registration
     # (i.e. registered with register_dispatch_impl)
     def register_factory_methods(self, methods):
@@ -71,9 +91,6 @@ class _Functional(ModuleType):
         wrapper = self.create_dispatch_wrapper(op_name)
         setattr(self, op_name, wrapper)
         return wrapper
-
-    # In the future, TorchArrow is going to support more device/backend, such as gpu/libcudf
-    device_to_backend = {"cpu": "velox"}
 
 
 functional = _Functional()

--- a/torcharrow/test/transformation/test_functional.py
+++ b/torcharrow/test/transformation/test_functional.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+import unittest
+
+import torcharrow as ta
+from torcharrow.functional import functional
+
+
+class _TestFunctionalBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Prepare input data as CPU dataframe
+        cls.base_df1 = ta.DataFrame(
+            {"a": [[11, 12, 13], [21, 22, 23, 24, 25, 26], [31, 32]]}
+        )
+
+        cls.setUpTestCaseData()
+
+    @classmethod
+    def setUpTestCaseData(cls):
+        # Override in subclass
+        # Python doesn't have native "abstract base test" support.
+        # So use unittest.SkipTest to skip in base class: https://stackoverflow.com/a/59561905.
+        raise unittest.SkipTest("abstract base test")
+
+    def test_slice(self):
+        self.assertEqual(
+            list(functional.slice(type(self).df1["a"], 2, 3)),
+            [[12, 13], [22, 23, 24], [32]],
+        )
+
+
+class TestFunctionalCpu(_TestFunctionalBase):
+    @classmethod
+    def setUpTestCaseData(cls):
+        cls.df1 = cls.base_df1.copy()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: For example, a tracing backend (which doesn't have "device")

Reviewed By: dracifer, vancexu

Differential Revision: D33769960

