### PR TITLE
Fix Modulus and update to generate expr eagerly

### DIFF
--- a/csrc/velox/column.cpp
+++ b/csrc/velox/column.cpp
@@ -467,7 +467,7 @@ std::string opCodeToFunctionName(BinaryOpCode opCode) {
       return "multiply";
     } break;
     case BinaryOpCode::Modulus: {
-      return "mod";
+      return "torcharrow_floormod";
     } break;
     case BinaryOpCode::Eq: {
       return "eq";

--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -53,6 +53,19 @@ inline void registerTorchArrowFunctions() {
   velox::registerFunction<udf_torcharrow_floordiv_int, int64_t, int64_t, int64_t>(
       {"torcharrow_floordiv"});
 
+  // Floor mod
+  velox::registerFunction<udf_torcharrow_floormod, float, float, float>({"torcharrow_floormod"});
+  velox::registerFunction<udf_torcharrow_floormod, double, double, double>(
+      {"torcharrow_floormod"});
+  velox::registerFunction<udf_torcharrow_floormod_int, int8_t, int8_t, int8_t>(
+      {"torcharrow_floormod"});
+  velox::registerFunction<udf_torcharrow_floormod_int, int16_t, int16_t, int16_t>(
+      {"torcharrow_floormod"});
+  velox::registerFunction<udf_torcharrow_floormod_int, int32_t, int32_t, int32_t>(
+      {"torcharrow_floormod"});
+  velox::registerFunction<udf_torcharrow_floormod_int, int64_t, int64_t, int64_t>(
+      {"torcharrow_floormod"});
+
   velox::exec::registerStatefulVectorFunction(
       "match_re",
       velox::functions::re2MatchSignatures(),

--- a/csrc/velox/functions/numeric_functions.h
+++ b/csrc/velox/functions/numeric_functions.h
@@ -37,4 +37,29 @@ FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& a, const TInput& b)
 }
 VELOX_UDF_END();
 
+// Torcharrow_floormod generates same result as Python mod, which is different from C++.
+// Reference: "floored division" in https://en.wikipedia.org/wiki/Modulo_operation
+VELOX_UDF_BEGIN(torcharrow_floormod_int)
+template <typename TOutput, typename TInput = TOutput>
+FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& a, const TInput& b) {
+  // Same as velox modulus, when inputs are integers and b is 0, return error
+  // instead of inf because int(inf) will overflow.
+  if (b == 0) {
+    VELOX_ARITHMETIC_ERROR("Cannot divide by 0");
+  }
+  // promote to float type to correctly compute floor divide for negative
+  // integers. e.g: -3 / 2 is -1, but floor(float(-3) / 2) is -2.
+  result = a - std::floor(float(a) / b) * b;
+  return true;
+}
+VELOX_UDF_END();
+
+VELOX_UDF_BEGIN(torcharrow_floormod)
+template <typename TOutput, typename TInput = TOutput>
+FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& a, const TInput& b) {
+  result = a - std::floor(a / b) * b;
+  return true;
+}
+VELOX_UDF_END();
+
 } // namespace facebook::torcharrow::functions

--- a/csrc/velox/functions/tests/FunctionsTest.cpp
+++ b/csrc/velox/functions/tests/FunctionsTest.cpp
@@ -66,11 +66,17 @@ class FunctionsTest : public functions::test::FunctionBaseTest {
   }
 };
 
-TEST_F(FunctionsTest, floor_divide) {
+TEST_F(FunctionsTest, floordiv) {
   assertExpression<int32_t>(
-      "torcharrow_floordiv(c0, c1)", {10, 11, -1, -34}, {2, 2, 2, 10}, {5, 5, -1, -4});
+      "torcharrow_floordiv(c0, c1)",
+      {10, 11, -1, -34},
+      {2, 2, 2, 10},
+      {5, 5, -1, -4});
   assertExpression<int64_t>(
-      "torcharrow_floordiv(c0, c1)", {10, 11, -1, -34}, {2, 2, 2, 10}, {5, 5, -1, -4});
+      "torcharrow_floordiv(c0, c1)",
+      {10, 11, -1, -34},
+      {2, 2, 2, 10},
+      {5, 5, -1, -4});
 
   assertError<int32_t>(
       "torcharrow_floordiv(c0, c1)", {10}, {0}, "division by zero");
@@ -87,6 +93,35 @@ TEST_F(FunctionsTest, floor_divide) {
       {10.5, -3.0, 1.0, 0.0},
       {2, 2, 0, 0},
       {5.0, -2.0, kInf, kNan});
+}
+
+TEST_F(FunctionsTest, floormod) {
+  assertExpression<int32_t>(
+      "torcharrow_floormod(c0, c1)",
+      {13, -13, 13, -13},
+      {3, 3, -3, -3},
+      {1, 2, -2, -1});
+  assertExpression<int64_t>(
+      "torcharrow_floormod(c0, c1)",
+      {13, -13, 13, -13},
+      {3, 3, -3, -3},
+      {1, 2, -2, -1});
+
+  assertError<int32_t>(
+      "torcharrow_floormod(c0, c1)", {10}, {0}, "Cannot divide by 0");
+  assertError<int32_t>(
+      "torcharrow_floormod(c0, c1)", {0}, {0}, "Cannot divide by 0");
+
+  assertExpression<float>(
+      "torcharrow_floormod(c0, c1)",
+      {13.0, -13.0, 13.0, -13.0, 1.0, 0},
+      {3.0, 3.0, -3.0, -3.0, 0, 0},
+      {1.0, 2.0, -2.0, -1.0, kNanF, kNanF});
+  assertExpression<double>(
+      "torcharrow_floormod(c0, c1)",
+      {13.0, -13.0, 13.0, -13.0, 1.0, 0},
+      {3.0, 3.0, -3.0, -3.0, 0, 0},
+      {1.0, 2.0, -2.0, -1.0, kNan, kNan});
 }
 
 } // namespace

--- a/torcharrow/test/lib_test/test_column.py
+++ b/torcharrow/test/lib_test/test_column.py
@@ -161,18 +161,15 @@ class TestSimpleColumns(BaseTestColumns):
 
         mod_scalar = col1.mod(3)
         self.assertEqual(mod_scalar.type().kind(), ta.TypeKind.BIGINT)
-        # Python's behavior for modulo on negative numbers is different from
-        # Velox/C++. e.g. -2 % 3 = 1 (because integer division in Python is
-        # floor(a/b), as opposed to trunc(a/b))
-        self.assert_Column(mod_scalar, [1, -2, None, 0, -1, None])
+        self.assert_Column(mod_scalar, [1, 1, None, 0, 2, None])
 
         mod_scalar = col1.mod(-3.0)
         self.assertEqual(mod_scalar.type().kind(), ta.TypeKind.REAL)
-        self.assert_Column(mod_scalar, [1.0, -2.0, None, 0.0, -1.0, None])
+        self.assert_Column(mod_scalar, [-2.0, -2.0, None, 0.0, -1.0, None])
 
         mod_scalar = col1.rmod(3)
         self.assertEqual(mod_scalar.type().kind(), ta.TypeKind.BIGINT)
-        self.assert_Column(mod_scalar, [0, 1, None, 0, 3, None])
+        self.assert_Column(mod_scalar, [0, -1, None, 0, -1, None])
 
         mod_scalar = col1.rmod(-3.0)
         self.assertEqual(mod_scalar.type().kind(), ta.TypeKind.REAL)

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -346,6 +346,9 @@ class TestNumericalColumn(unittest.TestCase):
         self.assertEqual(list(d % 2), [1, 1, 0])
         self.assertEqual(list(2 % d), [2, 2, 2])
         self.assertEqual(list(c % d), [0, 1, 3])
+        e = ta.Column([13, -13, 13, -13], device=self.device)
+        f = ta.Column([3, 3, -3, -3], device=self.device)
+        self.assertEqual(list(e % f), [1, 2, -2, -1])
 
         # TODO: Decide ...null handling.., bring back or ignore
 


### PR DESCRIPTION
Summary:
Problem:
TorchArrow mod operator works different from PyTorch/Pandas right now, because C++ and Python implement mod differently. Basically
- in python, result of a % b is: a - floor(a / b)
- in c++, result of a % b is: a - int(a / b)

This diff address it with a new velox udf floormod

Differential Revision: D33924566

