### PR TITLE
Support string plus a column

### DIFF
--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -129,7 +129,8 @@ class TestStringColumn(unittest.TestCase):
         concat2 = [x + "_suffix" for x in s1[:-1]] + [None]
         self.assertEqual(list(c1 + "_suffix"), concat2)
 
-        # TODO: also support str + IColumn
+        concat3 = ["prefix_" + x for x in s1[:-1]] + [None]
+        self.assertEqual(list("prefix_" + c1), concat3)
 
     def base_test_comparison(self):
         c = ta.Column(["abc", "de", "", "f", None], device=self.device)

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -147,6 +147,11 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
             assert isinstance(other, str)
             return functional.concat(self, other)._with_null(self.dtype.nullable)
 
+    def __radd__(self, other):
+        """Vectorized b + a."""
+        assert isinstance(other, str)
+        return functional.concat(other, self)._with_null(self.dtype.nullable)
+
     def _checked_binary_op_call(self, other, op_name):
         f = functional.__getattr__(op_name)
         nullable = self.dtype.nullable


### PR DESCRIPTION
Summary:
String concat exists in Pandas, not in TorchArrow.
```ta.Column(['x']) + 'y'
TypeError: StringColumnStd.add is not supported

pd.Series(['x']) + 'y'
0    xy
```
The string concatenation between Column and str, Column and Column have been fixed, but not for string + column.

Reviewed By: scotts

Differential Revision: D33340778

