### PR TITLE
Rethrow ZeroDivisionError for velox error to be consistent with Pytorch

### DIFF
--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -353,6 +353,12 @@ class TestNumericalColumn(unittest.TestCase):
         e = ta.Column([13, -13, 13, -13], device=self.device)
         f = ta.Column([3, 3, -3, -3], device=self.device)
         self.assertEqual(list(e % f), [1, 2, -2, -1])
+        # integer mod 0 -> exception
+        with self.assertRaises(ZeroDivisionError):
+            list(c % 0)
+        # float mod 0 -> nan
+        e = ta.Column([1.0], device=self.device)
+        self.assertTrue(isnan(list(e % 0)[0]))
 
         # TODO: Decide ...null handling.., bring back or ignore
 


### PR DESCRIPTION
Summary:
For `__floordiv__`, `__mod__`, we recently used velox udf to reach consistent behavior with Pytorch. But in case of division by 0, it directly expose RuntimeError wrapped with Velox trace instead of standard Python ZeroDivisionError.
This diff fixed this issue.

Reviewed By: OswinC

Differential Revision: D33954830

