### PR TITLE
Simplify to `from torcharrow import functional`

### DIFF
--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -2,6 +2,7 @@
 
 from . import pytorch  # noqa
 from . import velox_rt  # noqa
+from ._functional import functional
 from .icolumn import IColumn, Column, concat, if_else  # noqa
 from .idataframe import IDataFrame, DataFrame, me  # noqa
 from .ilist_column import IListColumn  # noqa
@@ -22,6 +23,7 @@ __all__ = [
     "if_else",
     "from_pylist",
     "me",
+    "functional",
     "IDataFrame",
     "IColumn",
     "INumericalColumn",

--- a/torcharrow/_functional.py
+++ b/torcharrow/_functional.py
@@ -6,6 +6,8 @@ from torcharrow.icolumn import IColumn
 
 
 class _Functional(ModuleType):
+    __file__ = "_functional.py"
+
     # In the future, TorchArrow is going to support more device/dispatch_key, such as gpu/libcudf
     _device_to_dispatch_key = {"cpu": "velox"}
     _column_class_to_dispatch_key = {}
@@ -15,6 +17,7 @@ class _Functional(ModuleType):
         self._backend_functional: Dict[str, ModuleType] = {}
         self._factory_methods: Set[str] = set()
 
+    # TODO: prefix all methods with "_"
     def get_backend_functional(self, dispatch_key):
         backend_functional = self._backend_functional.get(dispatch_key)
         if backend_functional is None:
@@ -45,6 +48,7 @@ class _Functional(ModuleType):
             op = self.get_backend_functional(dispatch_key).__getattr__(op_name)
             return op(*args)
 
+        # TODO: factory dispatch mechanism needs revamp and conslidate with the general constant literal handling
         def factory_dispatch(*args, size=None, device="cpu"):
             if size is None:
                 raise AssertionError(
@@ -82,8 +86,7 @@ class _Functional(ModuleType):
             )
         cls._column_class_to_dispatch_key[column_class] = dispatch_key
 
-    # TODO: Perhaps this should be part of dispatch backend registration
-    # (i.e. registered with register_dispatch_impl)
+    # TODO: factory dispatch mechanism needs revamp and conslidate with the general constant literal handling
     def register_factory_methods(self, methods):
         self._factory_methods.update(methods)
 

--- a/torcharrow/test/test_functional_cpu.py
+++ b/torcharrow/test/test_functional_cpu.py
@@ -4,7 +4,7 @@ import unittest
 import torcharrow as ta
 import torcharrow._torcharrow
 import torcharrow.dtypes as dt
-from torcharrow.functional import functional
+from torcharrow import functional
 from torcharrow.velox_rt.functional import velox_functional
 
 

--- a/torcharrow/test/transformation/test_functional.py
+++ b/torcharrow/test/transformation/test_functional.py
@@ -2,7 +2,7 @@
 import unittest
 
 import torcharrow as ta
-from torcharrow.functional import functional
+from torcharrow import functional
 
 
 class _TestFunctionalBase(unittest.TestCase):

--- a/torcharrow/velox_rt/functional.py
+++ b/torcharrow/velox_rt/functional.py
@@ -2,9 +2,7 @@
 import types
 
 import torcharrow._torcharrow as ta
-from torcharrow.functional import _Functional
-from torcharrow.functional import functional as functional_registry
-from torcharrow.scope import Scope
+from torcharrow._functional import functional as global_functional
 
 from .column import ColumnFromVelox
 
@@ -59,7 +57,7 @@ class VeloxFunctional(types.ModuleType):
 
             return ColumnFromVelox._from_velox(device, result_dtype, result_col, True)
 
-        if op_name in functional_registry._factory_methods:
+        if op_name in global_functional._factory_methods:
             return factory_dispatch
         else:
             return dispatch
@@ -76,5 +74,5 @@ class VeloxFunctional(types.ModuleType):
 
 
 velox_functional = VeloxFunctional()
-functional_registry.register_dispatch_impl("velox", velox_functional)
-functional_registry.register_factory_methods(["rand"])
+global_functional.register_dispatch_impl("velox", velox_functional)
+global_functional.register_factory_methods(["rand"])

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -3,7 +3,6 @@ import array as ar
 import warnings
 from typing import List, Callable
 
-import numpy as np
 import torcharrow as ta
 import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -1,7 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import array as ar
-import copy
-from collections import OrderedDict
 from dataclasses import dataclass
 from typing import List
 
@@ -11,8 +9,8 @@ import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as pytorch
 from tabulate import tabulate
+from torcharrow._functional import functional
 from torcharrow.dispatcher import Dispatcher
-from torcharrow.functional import functional
 from torcharrow.icolumn import IColumn
 from torcharrow.imap_column import IMapColumn, IMapMethods
 from torcharrow.scope import Scope

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -1,8 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import array as ar
 import math
 import operator
-import statistics
 from typing import Dict, List, Optional, Union, Callable
 
 import numpy as np
@@ -10,9 +8,9 @@ import torcharrow as ta
 import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as pytorch
+from torcharrow._functional import functional
 from torcharrow.dispatcher import Dispatcher
 from torcharrow.expression import expression
-from torcharrow.functional import functional
 from torcharrow.icolumn import IColumn
 from torcharrow.inumerical_column import INumericalColumn
 from torcharrow.trace import trace, traceproperty

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -6,9 +6,9 @@ import numpy as np
 import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 from tabulate import tabulate
+from torcharrow._functional import functional
 from torcharrow.dispatcher import Dispatcher
 from torcharrow.expression import expression
-from torcharrow.functional import functional
 from torcharrow.istring_column import IStringColumn, IStringMethods
 from torcharrow.trace import trace
 


### PR DESCRIPTION
Summary:
Previously , user has to do `from trocharrow.functional import functional`. This diff removes this "double functional" confusion.

Basically this diff renames `functional.py` to `_functional.py`, and adds `from ._functional import functional` in `__init__.py`.

It's now quite similar to `torch.ops`:
- The `ModuleType` in `_ops.py`: https://github.com/pytorch/pytorch/blob/5c6b897516ac59775d7d58692fad052c399c4ec3/torch/_ops.py#L181-L186
- `from _ops import ops` in `__init__.py`: https://github.com/pytorch/pytorch/blob/5c6b897516ac59775d7d58692fad052c399c4ec3/torch/__init__.py#L835

Previously:

```
# with import
from trocharrow.functional import functional
functional.foo(...)

# without import
torcharrow.functional.functional.foo(...)
```

After this:
```
# with import
from trocharrow import functional
functional.foo(...)

# without import
torcharrow.functional.foo(...)
```

-----------------------------------

I also considered registering  `torcharrow.functional` as a submodule:
```
sys.modules["torcharrow.functional"] = functional
```

So we can do
```
import torcharrow.functional as tf
tf.foo(...)
```

However, once we want to support namespace in `torcharrow.functional` (runtime submodule in a runtime module!), things can be quite complicated: https://stackoverflow.com/questions/47502063/creating-a-pseudo-module-that-creates-submodules-at-runtime ; see also PEP 302

So for now follows the `torch.ops` approach.

----------------------------

Differential Revision: D34012285

