### PR TITLE
implement native column creation from tuples

### DIFF
--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -6,7 +6,7 @@ from .icolumn import IColumn, Column, concat, if_else  # noqa
 from .idataframe import IDataFrame, DataFrame, me  # noqa
 from .ilist_column import IListColumn  # noqa
 from .imap_column import IMapColumn  # noqa
-from .interop import from_pylist, from_arrow  # noqa
+from .interop import from_pysequence, from_arrow  # noqa
 from .inumerical_column import INumericalColumn  # noqa
 from .istring_column import IStringColumn  # noqa
 
@@ -20,7 +20,7 @@ __all__ = [
     "Column",
     "concat",
     "if_else",
-    "from_pylist",
+    "from_pysequence",
     "me",
     "IDataFrame",
     "IColumn",

--- a/torcharrow/benchmark/benchmark_list_construction.py
+++ b/torcharrow/benchmark/benchmark_list_construction.py
@@ -46,7 +46,7 @@ class BenchmarkListConstruction:
             self.test_strings = test_strings
 
         def run(self):
-            col = Scope.default._FromPyList(self.test_strings, dtype=dt.string)
+            col = Scope.default._FromPySequence(self.test_strings, dtype=dt.string)
 
     def runListConstruction(
         self, runner: ListConstructionRunner, test_strings: Optional[List[str]] = None

--- a/torcharrow/benchmark/benchmark_vmap.py
+++ b/torcharrow/benchmark/benchmark_vmap.py
@@ -13,7 +13,7 @@ def prepare_list_int_col():
             element.append(i * j)
         elements.append(element)
 
-    return ta.from_pylist(elements, dtype=dt.List(dt.int64), device="cpu")
+    return ta.from_pysequence(elements, dtype=dt.List(dt.int64), device="cpu")
 
 
 def list_map_int(col: ta.IColumn):
@@ -32,7 +32,7 @@ def prepare_list_str_col():
             element.append(f"str{i}_{j}")
         elements.append(element)
 
-    return ta.from_pylist(elements, dtype=dt.List(dt.string), device="cpu")
+    return ta.from_pysequence(elements, dtype=dt.List(dt.string), device="cpu")
 
 
 def list_map_str(col: ta.IColumn):

--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -597,7 +597,7 @@ def infer_dtype_from_value(value):
     raise AssertionError(f"unexpected case {value} of type {type(value)}")
 
 
-def infer_dtype_from_prefix(prefix):
+def infer_dtype_from_prefix(prefix: ty.Sequence) -> ty.Optional[DType]:
     if len(prefix) == 0:
         return Any()
     dtype = infer_dtype_from_value(prefix[0])
@@ -663,7 +663,7 @@ def promote(l, r):
     return None
 
 
-def common_dtype(l, r):
+def common_dtype(l: DType, r: DType) -> ty.Optional[DType]:
     if is_void(l):
         return r.with_null()
     if is_void(r):

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -602,7 +602,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                     res.append(None)
 
         dtype = dtype or self._dtype
-        return Scope._FromPyList(res, dtype)
+        return Scope._FromPySequence(res, dtype)
 
     @trace
     @expression
@@ -1255,7 +1255,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
                 res.append(None)
             else:
                 res.append(pred(i, j))
-        return Scope._FromPyList(res, res_dtype)
+        return Scope._FromPySequence(res, res_dtype)
 
     def _compare(self, op, initial):
         assert initial in [True, False]

--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from typing import Optional, List, Union
+from typing import Optional, Sequence, Union
 
 import torcharrow.dtypes as dt
 
@@ -36,13 +36,13 @@ def from_pandas(data, dtype: Optional[dt.DType] = None, device: str = ""):
     raise NotImplementedError
 
 
-def from_pylist(
-    data: List, dtype: Optional[dt.DType] = None, device: str = ""
+def from_pysequence(
+    data: Sequence, dtype: Optional[dt.DType] = None, device: str = ""
 ) -> IColumn:
     """
-    Convert Python list of scalars or containers to a TorchArrow Column/DataFrame.
+    Convert Python sequence of scalars or containers to a TorchArrow Column/DataFrame.
     """
     # TODO(https://github.com/facebookresearch/torcharrow/issues/80) Infer dtype
     device = device or Scope.default.device
 
-    return Scope.default._FromPyList(data, dtype, device)
+    return Scope.default._FromPySequence(data, dtype, device)

--- a/torcharrow/interop_arrow.py
+++ b/torcharrow/interop_arrow.py
@@ -39,7 +39,7 @@ def _from_arrow_array(
 
     device = device or Scope.default.device
 
-    call = Dispatcher.lookup((dtype.typecode + "_fromarrow", device))
+    call = Dispatcher.lookup((dtype.typecode + "_from_arrow", device))
 
     return call(device, array, dtype)
 

--- a/torcharrow/inumerical_column.py
+++ b/torcharrow/inumerical_column.py
@@ -409,7 +409,7 @@ class INumericalColumn(IColumn):
                     res.append(None)
                 else:
                     res.append(fun(i, j))
-        return Scope._FromPyList(res, res_dtype)
+        return Scope._FromPySequence(res, res_dtype)
 
     def _is_zero_division_error(self, ex: Exception) -> bool:
         ex_str = str(ex)

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -119,7 +119,7 @@ class TestDataFrame(unittest.TestCase):
         with self.assertRaises(TypeError) as ex:
             a = ta.Column(data1, device=self.device)
         self.assertTrue(
-            "Cannot infer type from Python tuple" in str(ex.exception),
+            "Cannot infer type from nested Python tuple" in str(ex.exception),
             f"Exception message is not as expected: {str(ex.exception)}",
         )
         # data + dtype
@@ -166,7 +166,7 @@ class TestDataFrame(unittest.TestCase):
         with self.assertRaises(TypeError) as ex:
             df = ta.DataFrame(data3, device=self.device)
         self.assertTrue(
-            "Cannot infer type from Python tuple" in str(ex.exception),
+            "Cannot infer type from nested Python tuple" in str(ex.exception),
             f"Excpeion message is not as expected: {str(ex.exception)}",
         )
         # data + dtype

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -531,6 +531,15 @@ class TestNumericalColumn(unittest.TestCase):
         self.assertEqual(col3_float64.dtype, dt.Float64(nullable=True))
         self.assertEqual(list(col3_float64), data2)
 
+    def base_test_column_from_tuple(self):
+        data_int = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        col_int = ta.Column(data_int, device=self.device)
+        self.assertEqual(tuple(col_int), data_int)
+
+        data_float = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
+        col_float = ta.Column(data_float, device=self.device)
+        self.assertEqual(tuple(col_float), data_float)
+
     def base_test_column_from_numpy_array(self):
         seq_float = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
         seq_int = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/torcharrow/test/test_numerical_column_cpu.py
+++ b/torcharrow/test/test_numerical_column_cpu.py
@@ -60,6 +60,9 @@ class TestNumericalColumnCpu(TestNumericalColumn):
     def test_describe(self):
         return self.base_test_describe()
 
+    def test_column_from_tuple(self):
+        return self.base_test_column_from_tuple()
+
     def test_column_from_numpy_array(self):
         return self.base_test_column_from_numpy_array()
 

--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -29,6 +29,11 @@ class TestStringColumn(unittest.TestCase):
         # self.assertEqual(list(c._offsets), [0, 3, 5, 5, 6, 6])
         self.assertEqual(list(c), ["abc", "de", "", "f", None])
 
+    def base_test_string_column_from_tuple(self):
+        data_str = ("one", "two", "three", "four", "five", "six")
+        col_str = ta.Column(data_str, device=self.device)
+        self.assertEqual(tuple(col_str), data_str)
+
     def base_test_string_split_methods(self):
         s = ["a b c", "1,2,3", "d e f g h", "hello.this.is.very.very.very.very.long"]
         c = ta.Column(s, device=self.device)

--- a/torcharrow/test/test_string_column_cpu.py
+++ b/torcharrow/test/test_string_column_cpu.py
@@ -14,6 +14,9 @@ class TestStringColumnCpu(TestStringColumn):
     def test_append_offsets(self):
         self.base_test_append_offsets()
 
+    def test_string_column_from_tuple(self):
+        self.base_test_string_column_from_tuple()
+
     def test_comparison(self):
         return self.base_test_comparison()
 

--- a/torcharrow/velox_rt/column.py
+++ b/torcharrow/velox_rt/column.py
@@ -35,4 +35,4 @@ class ColumnFromVelox:
         concat_list = self.to_pylist()
         for column in columns:
             concat_list += column.to_pylist()
-        return Scope._FromPyList(concat_list, self.dtype)
+        return Scope._FromPySequence(concat_list, self.dtype)

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -49,7 +49,7 @@ class ListColumnCpu(ColumnFromVelox, IListColumn):
         )
 
     @staticmethod
-    def _fromlist(device: str, data: List[List], dtype: dt.List):
+    def _from_pysequence(device: str, data: List[List], dtype: dt.List):
         if dt.is_primitive(dtype.item_dtype):
             velox_column = velox.Column(get_velox_type(dtype), data)
             return ColumnFromVelox._from_velox(
@@ -61,11 +61,11 @@ class ListColumnCpu(ColumnFromVelox, IListColumn):
         else:
             warnings.warn(
                 "Complex types are not supported (properly) for "
-                "ListColumnCpu._fromlist yet. Falling back to the default "
+                "ListColumnCpu._from_pysequence yet. Falling back to the default "
                 "(inefficient) implementation"
             )
             assert len(data) <= 100000, (
-                "The default _fromlist implementation "
+                "The default _from_pysequence implementation "
                 f"will be too slow for {len(data)} elements"
             )
             col = ListColumnCpu._empty(device, dtype)
@@ -236,4 +236,6 @@ class ListMethodsCpu(IListMethods):
 # ------------------------------------------------------------------------------
 # registering the factory
 Dispatcher.register((dt.List.typecode + "_empty", "cpu"), ListColumnCpu._empty)
-Dispatcher.register((dt.List.typecode + "_fromlist", "cpu"), ListColumnCpu._fromlist)
+Dispatcher.register(
+    (dt.List.typecode + "_from_pysequence", "cpu"), ListColumnCpu._from_pysequence
+)

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -81,7 +81,7 @@ class MapColumnCpu(ColumnFromVelox, IMapColumn):
         return MapColumnCpu(device, dtype, key_data, item_data, mask)
 
     @staticmethod
-    def _fromlist(device, data: List, dtype):
+    def _from_pysequence(device, data: List, dtype: dt.List):
         # default implementation
         col = MapColumnCpu._empty(device, dtype)
         for i in data:
@@ -199,7 +199,9 @@ class MapColumnCpu(ColumnFromVelox, IMapColumn):
 # registering the factory
 Dispatcher.register((dt.Map.typecode + "_empty", "cpu"), MapColumnCpu._empty)
 Dispatcher.register((dt.Map.typecode + "_full", "cpu"), MapColumnCpu._full)
-Dispatcher.register((dt.Map.typecode + "_fromlist", "cpu"), MapColumnCpu._fromlist)
+Dispatcher.register(
+    (dt.Map.typecode + "_from_pysequence", "cpu"), MapColumnCpu._from_pysequence
+)
 # -----------------------------------------------------------------------------
 # MapMethods
 

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -3,7 +3,7 @@ import array as ar
 import math
 import operator
 import statistics
-from typing import Dict, List, Optional, Union, Callable
+from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torcharrow as ta
@@ -41,7 +41,9 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         return NumericalColumnCpu(device, dtype, velox.Column(get_velox_type(dtype)))
 
     @staticmethod
-    def _fromlist(device: str, data: List[Union[int, float, bool]], dtype: dt.DType):
+    def _from_pysequence(
+        device: str, data: Sequence[Union[int, float, bool]], dtype: dt.DType
+    ):
         velox_column = velox.Column(get_velox_type(dtype), data)
         return ColumnFromVelox._from_velox(
             device,
@@ -51,7 +53,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         )
 
     @staticmethod
-    def _fromarrow(device: str, array, dtype: dt.DType):
+    def _from_arrow(device: str, array, dtype: dt.DType):
         import pyarrow as pa
         from pyarrow.cffi import ffi
 
@@ -869,7 +871,9 @@ _primitive_types: List[dt.DType] = [
 ]
 for t in _primitive_types:
     Dispatcher.register((t.typecode + "_empty", "cpu"), NumericalColumnCpu._empty)
-    Dispatcher.register((t.typecode + "_fromlist", "cpu"), NumericalColumnCpu._fromlist)
     Dispatcher.register(
-        (t.typecode + "_fromarrow", "cpu"), NumericalColumnCpu._fromarrow
+        (t.typecode + "_from_pysequence", "cpu"), NumericalColumnCpu._from_pysequence
+    )
+    Dispatcher.register(
+        (t.typecode + "_from_arrow", "cpu"), NumericalColumnCpu._from_arrow
     )

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import array as ar
-from typing import List, Optional
+from typing import Optional, Sequence
 
 import numpy as np
 import torcharrow._torcharrow as velox
@@ -68,7 +68,7 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
         return StringColumnCpu(device, dtype, data, mask)
 
     @staticmethod
-    def _fromlist(device: str, data: List[str], dtype: dt.DType):
+    def _from_pysequence(device: str, data: Sequence[str], dtype: dt.DType):
         velox_column = velox.Column(get_velox_type(dtype), data)
         return ColumnFromVelox._from_velox(
             device,
@@ -79,13 +79,13 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
 
     # TODO Add native kernel support
     @staticmethod
-    def _fromarrow(device: str, array, dtype: dt.DType):
+    def _from_arrow(device: str, array, dtype: dt.DType):
         import pyarrow as pa
 
         assert isinstance(array, pa.Array)
 
         pydata = [i.as_py() for i in array]
-        return StringColumnCpu._fromlist(device, pydata, dtype)
+        return StringColumnCpu._from_pysequence(device, pydata, dtype)
 
     def _append_null(self):
         if self._finalized:
@@ -370,10 +370,10 @@ class StringMethodsCpu(IStringMethods):
 Dispatcher.register((dt.String.typecode + "_empty", "cpu"), StringColumnCpu._empty)
 Dispatcher.register((dt.String.typecode + "_full", "cpu"), StringColumnCpu._full)
 Dispatcher.register(
-    (dt.String.typecode + "_fromlist", "cpu"), StringColumnCpu._fromlist
+    (dt.String.typecode + "_from_pysequence", "cpu"), StringColumnCpu._from_pysequence
 )
 Dispatcher.register(
-    (dt.String.typecode + "_fromarrow", "cpu"), StringColumnCpu._fromarrow
+    (dt.String.typecode + "_from_arrow", "cpu"), StringColumnCpu._from_arrow
 )
 
 


### PR DESCRIPTION
Summary:
Implements native column creation from a Python tuple. We only support native column creation of tuples when all of the types they contain are the same.

Also addresses a TODO and refactors names of the dispatch functions and their corresponding keys (`_fromlist` becomes `_from_pylist`; `_fromarrow` becomes `_from_arrow`; and adds `_from_pytuple`).

Reviewed By: wenleix, OswinC, Tianshu-Bao

Differential Revision: D33862290

