### PR TITLE
implement native cast for numerical columns

### DIFF
--- a/csrc/velox/column.cpp
+++ b/csrc/velox/column.cpp
@@ -234,6 +234,23 @@ std::shared_ptr<velox::exec::ExprSet> BaseColumn::genUnaryExprSet(
       std::move(callTypedExprs), &TorchArrowGlobalStatic::execContext());
 }
 
+std::shared_ptr<velox::exec::ExprSet> BaseColumn::genCastExprSet(
+    std::shared_ptr<const velox::RowType> inputRowType,
+    velox::TypePtr outputType) {
+  using InputExprList =
+      std::vector<std::shared_ptr<const velox::core::ITypedExpr>>;
+  InputExprList fieldAccessTypedExprs{
+      std::make_shared<velox::core::FieldAccessTypedExpr>(
+          inputRowType->childAt(0),
+          inputRowType->nameOf(0))};
+
+  InputExprList castTypedExprs{std::make_shared<velox::core::CastTypedExpr>(
+      outputType, std::move(fieldAccessTypedExprs), false /* nullOnFailure */)};
+
+  return std::make_shared<velox::exec::ExprSet>(
+      std::move(castTypedExprs), &TorchArrowGlobalStatic::execContext());
+}
+
 std::unique_ptr<BaseColumn> BaseColumn::applyUnaryExprSet(
     std::shared_ptr<const velox::RowType> inputRowType,
     std::shared_ptr<velox::exec::ExprSet> exprSet) {

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -547,6 +547,16 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
 
     @trace
     @expression
+    def cast(self, dtype: dt.DType):
+        if self.null_count != 0 and not dtype.nullable:
+            raise ValueError("Cannot cast a column with nulls to a non-nullable type")
+
+        return ColumnFromVelox._from_velox(
+            self.device, dtype, self._data.cast(get_velox_type(dtype).kind()), True
+        )
+
+    @trace
+    @expression
     def ceil(self):
         return ColumnFromVelox._from_velox(
             self.device, self.dtype, self._data.ceil(), True


### PR DESCRIPTION
Summary: Overloads `cast()` in `NumericalColumnCpu`, passing off the implementation itself to Velox. The cast logic itself is generic, and implemented as `SimpleColumn<T>::cast<V>()` where `T` is the type of the column, and `V` is the type being casted to. On the Python side, we figure out the `TypeKind` for the type we're casting to, and pass that to the C++ binding layer. The C++ binding layer then uses the `TypeKind` to determine the appropriate `V` when calling `SimpleCOlumn<T>::cast<V>()`.

Reviewed By: wenleix, OswinC

Differential Revision: D33828276

