### PR TITLE
move velox type information into velox_rt directory

### DIFF
--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -846,50 +846,6 @@ def typeof_np_dtype(t: np.dtype) -> DType:
     )
 
 
-def dtype_of_velox_type(vtype: torcharrow._torcharrow.VeloxType) -> DType:
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.BOOLEAN:
-        return Boolean(nullable=True)
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.TINYINT:
-        return Int8(nullable=True)
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.SMALLINT:
-        return Int16(nullable=True)
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.INTEGER:
-        return Int32(nullable=True)
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.BIGINT:
-        return Int64(nullable=True)
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.REAL:
-        return Float32(nullable=True)
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.DOUBLE:
-        return Float64(nullable=True)
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.VARCHAR:
-        return String(nullable=True)
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.ARRAY:
-        return List(
-            item_dtype=dtype_of_velox_type(
-                ty.cast(torcharrow._torcharrow.VeloxArrayType, vtype).element_type()
-            ),
-            nullable=True,
-        )
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.MAP:
-        vtype = ty.cast(torcharrow._torcharrow.VeloxMapType, vtype)
-        return Map(
-            key_dtype=dtype_of_velox_type(vtype.key_type()),
-            item_dtype=dtype_of_velox_type(vtype.value_type()),
-            nullable=True,
-        )
-    if vtype.kind() == torcharrow._torcharrow.TypeKind.ROW:
-        vtype = ty.cast(torcharrow._torcharrow.VeloxRowType, vtype)
-        fields = [
-            Field(name=vtype.name_of(i), dtype=dtype_of_velox_type(vtype.child_at(i)))
-            for i in range(vtype.size())
-        ]
-        return Struct(fields=fields, nullable=True)
-
-    raise AssertionError(
-        f"translation of Velox typekind {vtype.kind()} to dtype unsupported"
-    )
-
-
 def cast_as(dtype):
     if is_string(dtype):
         return str

--- a/torcharrow/test/test_dtypes.py
+++ b/torcharrow/test/test_dtypes.py
@@ -17,8 +17,8 @@ from torcharrow.dtypes import (
     is_int64,
     is_struct,
     string,
-    dtype_of_velox_type,
 )
+from torcharrow.velox_rt.typing import dtype_of_velox_type
 
 
 class TestTypes(unittest.TestCase):

--- a/torcharrow/velox_rt/__init__.py
+++ b/torcharrow/velox_rt/__init__.py
@@ -10,6 +10,6 @@ import torcharrow._torcharrow
 # Initialize and register Velox functional
 import torcharrow.velox_rt.functional
 
-torcharrow._torcharrow.BaseColumn.dtype = (
-    lambda self: torcharrow.dtypes.dtype_of_velox_type(self.type())
-)
+from .typing import dtype_of_velox_type
+
+torcharrow._torcharrow.BaseColumn.dtype = lambda self: dtype_of_velox_type(self.type())

--- a/torcharrow/velox_rt/typing.py
+++ b/torcharrow/velox_rt/typing.py
@@ -1,54 +1,87 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import torcharrow._torcharrow as velox
-from torcharrow.dtypes import (
-    get_underlying_dtype,
-    DType,
-    int8,
-    int16,
-    int32,
-    int64,
-    float32,
-    float64,
-    string,
-    boolean,
-    List as List_,
-    Map,
-    Struct,
-)
+import typing as ty
 
+import torcharrow._torcharrow as velox
+import torcharrow.dtypes as dt
 
 # ------------------------------------------------------------------------------
 
 
-def get_velox_type(dtype: DType):
-    underlying_dtype = get_underlying_dtype(dtype)
-    if underlying_dtype == int64:
+def get_velox_type(dtype: dt.DType) -> velox.VeloxType:
+    underlying_dtype = dt.get_underlying_dtype(dtype)
+    if underlying_dtype == dt.int64:
         return velox.VeloxType_BIGINT()
-    elif underlying_dtype == int32:
+    elif underlying_dtype == dt.int32:
         return velox.VeloxType_INTEGER()
-    elif underlying_dtype == int16:
+    elif underlying_dtype == dt.int16:
         return velox.VeloxType_SMALLINT()
-    elif underlying_dtype == int8:
+    elif underlying_dtype == dt.int8:
         return velox.VeloxType_TINYINT()
-    elif underlying_dtype == float32:
+    elif underlying_dtype == dt.float32:
         return velox.VeloxType_REAL()
-    elif underlying_dtype == float64:
+    elif underlying_dtype == dt.float64:
         return velox.VeloxType_DOUBLE()
-    elif underlying_dtype == string:
+    elif underlying_dtype == dt.string:
         return velox.VeloxType_VARCHAR()
-    elif underlying_dtype == boolean:
+    elif underlying_dtype == dt.boolean:
         return velox.VeloxType_BOOLEAN()
-    elif isinstance(underlying_dtype, List_):
+    elif isinstance(underlying_dtype, dt.List):
         return velox.VeloxArrayType(get_velox_type(underlying_dtype.item_dtype))
-    elif isinstance(underlying_dtype, Map):
+    elif isinstance(underlying_dtype, dt.Map):
         return velox.VeloxMapType(
             get_velox_type(underlying_dtype.key_dtype),
             get_velox_type(underlying_dtype.item_dtype),
         )
-    elif isinstance(underlying_dtype, Struct):
+    elif isinstance(underlying_dtype, dt.Struct):
         return velox.VeloxRowType(
             [f.name for f in underlying_dtype.fields],
             [get_velox_type(f.dtype) for f in underlying_dtype.fields],
         )
     else:
         raise NotImplementedError(str(underlying_dtype))
+
+
+def dtype_of_velox_type(vtype: velox.VeloxType) -> dt.DType:
+    if vtype.kind() == velox.TypeKind.BOOLEAN:
+        return dt.Boolean(nullable=True)
+    if vtype.kind() == velox.TypeKind.TINYINT:
+        return dt.Int8(nullable=True)
+    if vtype.kind() == velox.TypeKind.SMALLINT:
+        return dt.Int16(nullable=True)
+    if vtype.kind() == velox.TypeKind.INTEGER:
+        return dt.Int32(nullable=True)
+    if vtype.kind() == velox.TypeKind.BIGINT:
+        return dt.Int64(nullable=True)
+    if vtype.kind() == velox.TypeKind.REAL:
+        return dt.Float32(nullable=True)
+    if vtype.kind() == velox.TypeKind.DOUBLE:
+        return dt.Float64(nullable=True)
+    if vtype.kind() == velox.TypeKind.VARCHAR:
+        return dt.String(nullable=True)
+    if vtype.kind() == velox.TypeKind.ARRAY:
+        return dt.List(
+            item_dtype=dtype_of_velox_type(
+                ty.cast(velox.VeloxArrayType, vtype).element_type()
+            ),
+            nullable=True,
+        )
+    if vtype.kind() == velox.TypeKind.MAP:
+        vtype = ty.cast(velox.VeloxMapType, vtype)
+        return dt.Map(
+            key_dtype=dtype_of_velox_type(vtype.key_type()),
+            item_dtype=dtype_of_velox_type(vtype.value_type()),
+            nullable=True,
+        )
+    if vtype.kind() == velox.TypeKind.ROW:
+        vtype = ty.cast(velox.VeloxRowType, vtype)
+        fields = [
+            dt.Field(
+                name=vtype.name_of(i), dtype=dtype_of_velox_type(vtype.child_at(i))
+            )
+            for i in range(vtype.size())
+        ]
+        return dt.Struct(fields=fields, nullable=True)
+
+    raise AssertionError(
+        f"translation of Velox typekind {vtype.kind()} to dtype unsupported"
+    )


### PR DESCRIPTION
Summary: Moves the function `dtype_of_velox_type()` from `torcharrow/dtypes.py` into `torcharrow/velox_rt/typing.py`. The principle here to to keep all Velox-specific implementation details (such as how to map the types)  located in `torcharrow/velox_rt`; the TorchArrow layer should not know about Velox internals.

Reviewed By: wenleix

Differential Revision: D34156037

