### PR TITLE
Fix round operator to use velox udf

### DIFF
--- a/csrc/velox/column.h
+++ b/csrc/velox/column.h
@@ -496,7 +496,7 @@ class SimpleColumn : public BaseColumn {
     const static auto inputRowType =
         velox::ROW({"c0"}, {velox::CppToType<T>::create()});
     const static auto opHandle = OperatorHandle::fromCall(
-        inputRowType, velox::CppToType<T>::create(), "round");
+        inputRowType, velox::CppToType<T>::create(), "torcharrow_round");
     return opHandle->call(_delegate);
   }
 

--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -83,6 +83,37 @@ inline void registerTorchArrowFunctions() {
   velox::registerFunction<torcharrow_pow_int, int64_t, int64_t, int64_t>(
       {"torcharrow_pow"});
 
+  // Round
+  velox::registerFunction<torcharrow_round, float, float>({"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, double, double>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, int8_t, int8_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, int16_t, int16_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, int32_t, int32_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, int64_t, int64_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, float, bool>({"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, float, float, int64_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, double, double, int64_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, int8_t, int8_t, int64_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, int16_t, int16_t, int64_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, int32_t, int32_t, int64_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, int64_t, int64_t, int64_t>(
+      {"torcharrow_round"});
+  velox::registerFunction<torcharrow_round, float, bool, int64_t>(
+      {"torcharrow_round"});
+
+  // TODO: consider to refactor registration code with helper functions
+  // to save some lines, like https://fburl.com/code/dk6zi7t3
+
   velox::exec::registerStatefulVectorFunction(
       "match_re",
       velox::functions::re2MatchSignatures(),

--- a/torcharrow/inumerical_column.py
+++ b/torcharrow/inumerical_column.py
@@ -226,7 +226,12 @@ class INumericalColumn(IColumn):
     @trace
     @expression
     def round(self, decimals=0):
-        """Round each value in a data to the given number of decimals."""
+        """Round each value in a data to the given number of decimals.
+
+        decimals : int, default 0
+            Number of decimal places to round to. If decimals is negative,
+            it specifies the number of positions to the left of the decimal point.
+        """
         return self._vectorize(partial(round, ndigits=decimals), self.dtype)
 
     # cumsum

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -487,12 +487,36 @@ class TestNumericalColumn(unittest.TestCase):
         self.assertEqual(list(C.floor())[:-1], [floor(i) for i in c])
         self.assertEqual(list(C.floor())[-1], None)
 
-        self.assertEqual(list(C.round()), [round(i) for i in c] + [None])
-
+        self.assertEqual(list(C.round()), list(np.array(c).round()) + [None])
         numpy.testing.assert_almost_equal(
-            list(C.round(2))[:-1], [round(i, 2) for i in c], 6
+            list(C.round(2))[:-1], list(np.array(c).round(2)), 6
         )
         self.assertEqual(list(C.round(2))[-1], None)
+        c_round_list = [
+            1.1,
+            1.5,
+            1.8,
+            2.5,
+            -1.1,
+            -1.5,
+            -1.8,
+            -2.5,
+            1.12,
+            1.15,  # note: round(1.15, 1) is 1.1 in python, but 1.2 in Pandas/Numpy
+            1.25,
+            11.1,
+            11.5,
+            11.9,
+        ]
+        c_round = ta.Column(c_round_list, device=self.device)
+        self.assertEqual(list(c_round.round()), list(np.array(c_round_list).round()))
+        for decimals in [-1, 1, 2]:
+            numpy.testing.assert_almost_equal(
+                list(c_round.round(decimals)),
+                list(np.array(c_round_list).round(decimals)),
+                6,
+            )
+
         # self.assertEqual(list(C.hash_values()), [hash(i) for i in c] + [None])
 
         c1 = ta.Column(

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -572,18 +572,9 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def round(self, decimals=0):
-        self._prototype_support_warning("round")
-
-        # TODO: round(-2.5) returns -2.0 in Numpy/PyTorch but returns -3.0 in Velox
-        # return ColumnFromVelox._from_velox(self.device, self.dtype, self._data.round(), True)
-
-        col = velox.Column(get_velox_type(self.dtype))
-        for i in range(len(self)):
-            if self._getmask(i):
-                col.append_null()
-            else:
-                col.append(round(self._getdata(i), decimals))
-        return ColumnFromVelox._from_velox(self.device, self.dtype, col, True)
+        return functional.torcharrow_round(self, decimals)._with_null(
+            self.dtype.nullable
+        )
 
     @trace
     @expression


### PR DESCRIPTION
Summary:
Created torcharrow_round udf to make TA be consistent with Pandas/Numpy. The target behavior is "round half to even" approach:
if the fractional part of d is 0.5 then round to the nearest even integer.
The implementation follows Numpy(Pandas) implemenation.
BTW Pytorch doesn't support decimal, but we do (TA round becomes superset of pytorch round)

Differential Revision: D34166948

