### PR TITLE
Pyre init

### DIFF
--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -12,6 +12,7 @@ from .inumerical_column import INumericalColumn  # noqa
 from .istring_column import IStringColumn  # noqa
 
 try:
+    # pyre-fixme[21]: Could not find module `torcharrow.version`.
     from .version import __version__  # noqa: F401
 except ImportError:
     pass

--- a/torcharrow/_interop.py
+++ b/torcharrow/_interop.py
@@ -192,6 +192,7 @@ def _arrowtype_to_dtype(t: pa.DataType, nullable: bool) -> dt.DType:
         return dt.String(nullable)
     if pa.types.is_struct(t):
         return dt.Struct(
+            # pyre-fixme[16]: `DataType` has no attribute `__iter__`.
             [dt.Field(f.name, _arrowtype_to_dtype(f.type, f.nullable)) for f in t],
             nullable,
         )

--- a/torcharrow/_pytorch/common.py
+++ b/torcharrow/_pytorch/common.py
@@ -266,6 +266,7 @@ class DefaultTensorConversion(TensorConversion):
 
 
 @final
+# pyre-fixme[39]: `(...) -> Any` is not a valid parent class.
 class PadSequence(Callable):
     """
     Pad a batch of variable length numeric lists with ``padding_value``.
@@ -282,6 +283,7 @@ class PadSequence(Callable):
 
 def _dtype_to_pytorch_dtype(dtype: dt.DType) -> torch.dtype:
     # our names of types conveniently almost match
+    # pyre-fixme[16]: `DType` has no attribute `name`.
     torch_dtype_name = "bool" if dtype.name == "boolean" else dtype.name
     if not hasattr(torch, torch_dtype_name):
         raise ValueError(f"Can't convert {dtype} to PyTorch")

--- a/torcharrow/_pytorch/rec.py
+++ b/torcharrow/_pytorch/rec.py
@@ -2,6 +2,8 @@
 from typing import Callable
 
 import torch
+
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow as _torcharrow
 import torcharrow.dtypes as dt
 from typing_extensions import final
@@ -10,6 +12,7 @@ from .common import _dtype_to_pytorch_dtype
 
 
 @final
+# pyre-fixme[39]: `(...) -> Any` is not a valid parent class.
 class Dense(Callable):
     """
     Predefined conversion callable for dense features.
@@ -51,6 +54,7 @@ class Dense(Callable):
 
 
 @final
+# pyre-fixme[39]: `(...) -> Any` is not a valid parent class.
 class Sparse(Callable):
     """
     Predefined conversion callable for sparse features.
@@ -80,6 +84,7 @@ class Sparse(Callable):
 
 
 @final
+# pyre-fixme[39]: `(...) -> Any` is not a valid parent class.
 class WeightedSparse(Callable):
     """
     Predefined conversion callable for weighted sparse features.
@@ -105,6 +110,7 @@ class WeightedSparse(Callable):
 
 
 @final
+# pyre-fixme[39]: `(...) -> Any` is not a valid parent class.
 class Embedding(Callable):
     """
     Predefined conversion callable for embedding features.
@@ -119,6 +125,7 @@ class Embedding(Callable):
 
 
 @final
+# pyre-fixme[39]: `(...) -> Any` is not a valid parent class.
 class Scalar(Callable):
     """
     Predefined conversion callable for scalar features.

--- a/torcharrow/benchmark/benchmark_list_construction.py
+++ b/torcharrow/benchmark/benchmark_list_construction.py
@@ -25,6 +25,7 @@ class BenchmarkListConstruction:
         def run(self):
             pass
 
+    # pyre-fixme[13]: Attribute `test_strings` is never initialized.
     class AppendRunner(ListConstructionRunner):
         def __init__(self):
             self.test_strings: List[str]
@@ -38,6 +39,7 @@ class BenchmarkListConstruction:
                 col._append(s)
             col._finalize()
 
+    # pyre-fixme[13]: Attribute `test_strings` is never initialized.
     class FromlistRunner(ListConstructionRunner):
         def __init__(self):
             self.test_strings: List[str]
@@ -51,16 +53,20 @@ class BenchmarkListConstruction:
     def runListConstruction(
         self, runner: ListConstructionRunner, test_strings: Optional[List[str]] = None
     ) -> List[int]:
+        # pyre-fixme[16]: `BenchmarkListConstruction` has no attribute `test_strings`.
         test_strings = test_strings or self.test_strings
+        # pyre-fixme[7]: Expected `List[int]` but got `List[float]`.
         return timeit.repeat(
             stmt=lambda: runner.run(),
             setup=lambda: runner.setup(test_strings),
+            # pyre-fixme[16]: `BenchmarkListConstruction` has no attribute `nLoop`.
             number=self.nLoop,
         )
 
     def printResult(self, result: List[int]):
         print(
             f"min of {len(result)} repeats is {min(result)} seconds over "
+            # pyre-fixme[16]: `BenchmarkListConstruction` has no attribute `nLoop`.
             f"{self.nLoop} loops, or {min(result)/self.nLoop} seconds per loop"
         )
 

--- a/torcharrow/benchmark/benchmark_vmap.py
+++ b/torcharrow/benchmark/benchmark_vmap.py
@@ -17,10 +17,12 @@ def prepare_list_int_col():
 
 
 def list_map_int(col: ta.IColumn):
+    # pyre-fixme[16]: `IColumn` has no attribute `list`.
     return col.list.map(lambda val: val + 1)
 
 
 def list_vmap_int(col: ta.IColumn):
+    # pyre-fixme[16]: `IColumn` has no attribute `list`.
     return col.list.vmap(lambda col: col + 1)
 
 
@@ -36,10 +38,12 @@ def prepare_list_str_col():
 
 
 def list_map_str(col: ta.IColumn):
+    # pyre-fixme[16]: `IColumn` has no attribute `list`.
     return col.list.map(lambda val: val + "_1")
 
 
 def list_vmap_str(col: ta.IColumn):
+    # pyre-fixme[16]: `IColumn` has no attribute `list`.
     return col.list.vmap(lambda col: col + "_1")
 
 

--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -7,6 +7,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace, is_dataclass
 
 import numpy as np
+
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow
 import typing_inspect
 
@@ -275,6 +277,7 @@ class Struct(DType):
         for idx, field in enumerate(self.fields):
             if field.name == name:
                 return idx
+        # pyre-fixme[7]: Expected `int` but got `None`.
         return None
 
     def __post_init__(self):
@@ -539,10 +542,13 @@ def contains_tuple(t: DType):
     if is_tuple(t):
         return True
     if is_list(t):
+        # pyre-fixme[16]: `DType` has no attribute `item_dtype`.
         return contains_tuple(t.item_dtype)
     if is_map(t):
+        # pyre-fixme[16]: `DType` has no attribute `key_dtype`.
         return contains_tuple(t.key_dtype) or contains_tuple(t.item_dtype)
     if is_struct(t):
+        # pyre-fixme[16]: `DType` has no attribute `fields`.
         return any(contains_tuple(f.dtype) for f in t.fields)
 
     return False
@@ -614,6 +620,7 @@ def infer_dtype_from_prefix(prefix: ty.Sequence) -> ty.Optional[DType]:
 
 def infer_dype_from_callable_hint(
     func: ty.Callable,
+    # pyre-fixme[31]: Expression `Type])` is not a valid type.
 ) -> (ty.Optional[DType], ty.Optional[ty.Type]):
     dtype = None
     py_type = None
@@ -677,6 +684,7 @@ def common_dtype(l: DType, r: DType) -> ty.Optional[DType]:
         return String(l.nullable or r.nullable)
     if is_boolean_or_numerical(l) and is_boolean_or_numerical(r):
         return promote(l, r)
+    # pyre-fixme[16]: `DType` has no attribute `fields`.
     if is_tuple(l) and is_tuple(r) and len(l.fields) == len(r.fields):
         res = []
         for i, j in zip(l.fields, r.fields):
@@ -686,7 +694,9 @@ def common_dtype(l: DType, r: DType) -> ty.Optional[DType]:
             res.append(m)
         return Tuple(res).with_null(l.nullable or r.nullable)
     if is_map(l) and is_map(r):
+        # pyre-fixme[16]: `DType` has no attribute `key_dtype`.
         k = common_dtype(l.key_dtype, r.key_dtype)
+        # pyre-fixme[16]: `DType` has no attribute `item_dtype`.
         i = common_dtype(l.item_dtype, r.item_dtype)
         return (
             Map(k, i).with_null(l.nullable or r.nullable)

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -1309,6 +1309,7 @@ class IColumn(ty.Sized, ty.Iterable, abc.ABC):
             from . import pytorch
 
             pytorch.ensure_available()
+            # pyre-fixme[16]: Module `pytorch` has no attribute `from_tensor`.
             ret = pytorch.from_tensor(raw, dtype=dtype)
         elif format == "python" or format == "column":
             ret = ta.Column(raw, dtype=dtype)

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -175,6 +175,7 @@ class IDataFrame(IColumn):
         raise self._not_supported("_set_field_data")
 
     def __contains__(self, key: str) -> bool:
+        # pyre-fixme[16]: `DType` has no attribute `fields`.
         for f in self.dtype.fields:
             if key == f.name:
                 return True
@@ -188,9 +189,11 @@ class IDataFrame(IColumn):
         else:
             col = ta.Column(value)
 
+        # pyre-fixme[16]: `DType` has no attribute `fields`.
         empty_df = len(self.dtype.fields) == 0
 
         # Update dtype
+        # pyre-fixme[16]: `DType` has no attribute `get_index`.
         idx = self.dtype.get_index(name)
         if idx is None:
             # append column

--- a/torcharrow/ilist_column.py
+++ b/torcharrow/ilist_column.py
@@ -81,6 +81,8 @@ class IListMethods(abc.ABC):
 
         return me._vectorize(fun, me.dtype.item_dtype.with_null(me.dtype.nullable))
 
+    # pyre-fixme[9]: start has type `int`; used as `None`.
+    # pyre-fixme[9]: stop has type `int`; used as `None`.
     def slice(self, start: int = None, stop: int = None) -> IListColumn:
         """Slice sublist from each element in the column"""
         self._parent._prototype_support_warning("list.slice")
@@ -156,6 +158,7 @@ class IListMethods(abc.ABC):
         def func(xs):
             return functools.reduce(fun, xs, initializer)
 
+        # pyre-fixme[16]: `DType` has no attribute `item_dtype`.
         dtype = me.dtype.item_dtype if dtype is None else dtype
         return me._vectorize(func, dtype)
 

--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -45,4 +45,5 @@ def from_pysequence(
     # TODO(https://github.com/facebookresearch/torcharrow/issues/80) Infer dtype
     device = device or Scope.default.device
 
+    # pyre-fixme[6]: For 2nd param expected `DType` but got `Optional[DType]`.
     return Scope.default._FromPySequence(data, dtype, device)

--- a/torcharrow/interop_arrow.py
+++ b/torcharrow/interop_arrow.py
@@ -10,6 +10,7 @@ from .scope import Scope
 
 
 def _from_arrow_array(
+    # pyre-fixme[11]: Annotation `Array` is not defined as a type.
     array,  # type: pa.Array
     dtype: Optional[dt.DType] = None,
     device: str = "",
@@ -27,6 +28,7 @@ def _from_arrow_array(
     # vice versa), (ii) when we bring in a stricter type system in Velox
     # to allow functions to only be invokable on non-null types we
     # increase the amount of places we can use the from_arrow result
+    # pyre-fixme[16]: `Array` has no attribute `type`.
     dtype_from_arrowtype = _arrowtype_to_dtype(array.type, array.null_count > 0)
     if dtype and (
         dt.get_underlying_dtype(dtype) != dt.get_underlying_dtype(dtype_from_arrowtype)
@@ -45,6 +47,7 @@ def _from_arrow_array(
 
 
 def _from_arrow_table(
+    # pyre-fixme[11]: Annotation `Table` is not defined as a type.
     table,  # type: pa.Table
     dtype: Optional[dt.DType] = None,
     device: str = "",
@@ -78,6 +81,7 @@ def _from_arrow_table(
         df_data[field.name] = _from_arrow_array(
             table[i].chunk(0),
             dtype=(
+                # pyre-fixme[16]: `DType` has no attribute `get`.
                 dtype.get(field.name)
                 if dtype is not None
                 else _arrowtype_to_dtype(field.type, field.nullable)

--- a/torcharrow/inumerical_column.py
+++ b/torcharrow/inumerical_column.py
@@ -32,7 +32,11 @@ class INumericalColumn(IColumn):
             return self
         elif isinstance(self, NumericalColumnCpu):
             return Scope.default._FullColumn(
-                self._data, self.dtype, device=device, mask=self._mask
+                self._data,
+                self.dtype,
+                device=device,
+                # pyre-fixme[16]: `NumericalColumnCpu` has no attribute `_mask`.
+                mask=self._mask,
             )
         else:
             raise AssertionError("unexpected case")

--- a/torcharrow/scope.py
+++ b/torcharrow/scope.py
@@ -31,6 +31,7 @@ class Counter:
 
 # Scope will be deprecated in the future.
 # Please DON'T use it in user-level code.
+# pyre-fixme[13]: Attribute `default` is never initialized.
 class Scope:
     """
     This class will be deprecated in the future.
@@ -174,6 +175,8 @@ class Scope:
             (data, dtype) = (dtype, data)
 
         # data is a list or a tuple; we only allow type inference from flat tuples
+        # pyre-fixme[6]: For 2nd param expected `Union[Type[typing.Any],
+        #  typing.Tuple[Type[typing.Any], ...]]` but got `_SpecialForm`.
         if isinstance(data, ty.List) or isinstance(data, ty.Tuple):
             # TODO: infer the type from the whole list
             dtype = dtype or dt.infer_dtype_from_prefix(data[:7])

--- a/torcharrow/test/integration/test_criteo.py
+++ b/torcharrow/test/integration/test_criteo.py
@@ -55,6 +55,8 @@ DTYPE = dt.Struct(
 # TODO: allow to use to_tensor with Callable
 # TODO: implement conversion in native C++
 class _DenseConversion(tap.TensorConversion):
+    # pyre-fixme[14]: `to_tensor` overrides method defined in `TensorConversion`
+    #  inconsistently.
     def to_tensor(self, df: ta.IDataFrame):
         # Default to_tensor, each field is a Tensor
         tensors = df.to_tensor()
@@ -69,6 +71,8 @@ class _DenseConversion(tap.TensorConversion):
 # TODO: this is not a general purpose JaggedTensor conversion -- it leverages the fact that in Criteo preproc, each array is single element
 # TODO: implement general purpose jagged sparse tensor conversion in native C++
 class _CriteoJaggedTensorConversion(tap.TensorConversion):
+    # pyre-fixme[14]: `to_tensor` overrides method defined in `TensorConversion`
+    #  inconsistently.
     def to_tensor(self, df: ta.IDataFrame):
         # TODO: Implement df.size(), similar to Pandas
         num_arrays = len(df) * len(df.columns)

--- a/torcharrow/test/lib_test/test_column.py
+++ b/torcharrow/test/lib_test/test_column.py
@@ -6,11 +6,13 @@ import unittest
 from dataclasses import dataclass
 from typing import Union, List, Any
 
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 # @manual=//pytorch/torcharrow/csrc/velox:_torcharrow
 import torcharrow._torcharrow as ta
 
 
 class BaseTestColumns(unittest.TestCase):
+    # pyre-fixme[11]: Annotation `BaseColumn` is not defined as a type.
     def assert_Column(self, col: ta.BaseColumn, val: List[Any]):
         self.assertEqual(len(col), len(val))
         self.assertEqual(col.get_null_count(), sum(x is None for x in val))
@@ -438,13 +440,21 @@ class TestSimpleColumns(BaseTestColumns):
 
 
 def is_same_type(a, b) -> bool:
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if isinstance(a, ta.VeloxType_BIGINT):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return isinstance(b, ta.VeloxType_BIGINT)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if isinstance(a, ta.VeloxType_VARCHAR):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return isinstance(b, ta.VeloxType_VARCHAR)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if isinstance(a, ta.VeloxType_BOOLEAN):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return isinstance(b, ta.VeloxType_BOOLEAN)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if isinstance(a, ta.VeloxArrayType):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return isinstance(b, ta.VeloxArrayType) and is_same_type(
             a.element_type(), b.element_type()
         )
@@ -474,10 +484,12 @@ def infer_column(data) -> ta.BaseColumn:
 def resolve_column_with_arbitrary_type(unresolved: Unresolved) -> ta.BaseColumn:
     if isinstance(unresolved, UnresolvedArray):
         element = resolve_column_with_arbitrary_type(unresolved.element_type)
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         col = ta.Column(ta.VeloxArrayType(element.type()))
         col.append(element)
         return col
     else:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return ta.Column(ta.VeloxType_BIGINT())
 
 
@@ -525,6 +537,7 @@ def _infer_column(data) -> Union[ta.BaseColumn, Unresolved, None]:
                 return UnresolvedArray(union_type)
             else:
                 resolved_item_type = union_type
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 col = ta.Column(ta.VeloxArrayType(resolved_item_type))
                 for item_col, item in zip(inferred_columns, data):
                     if item is None:
@@ -558,10 +571,16 @@ def _infer_column(data) -> Union[ta.BaseColumn, Unresolved, None]:
             keys_array_type = inferred_keys_array_columns.type()
             values_array_type = inferred_values_array_columns.type()
 
+            # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
             if isinstance(keys_array_type, ta.VeloxArrayType) and isinstance(
-                values_array_type, ta.VeloxArrayType
+                values_array_type,
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
+                ta.VeloxArrayType,
             ):
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 col = ta.Column(
+                    # pyre-fixme[16]: Module `torcharrow` has no attribute
+                    #  `_torcharrow`.
                     ta.VeloxMapType(
                         keys_array_type.element_type(), values_array_type.element_type()
                     )
@@ -570,7 +589,11 @@ def _infer_column(data) -> Union[ta.BaseColumn, Unresolved, None]:
                     if item is None:
                         col.append_null()
                     else:
+                        # pyre-fixme[16]: Module `torcharrow` has no attribute
+                        #  `_torcharrow`.
                         key_col = ta.Column(keys_array_type.element_type())
+                        # pyre-fixme[16]: Module `torcharrow` has no attribute
+                        #  `_torcharrow`.
                         value_col = ta.Column(values_array_type.element_type())
                         for key, value in item.items():
                             key_col.append(key)
@@ -585,14 +608,19 @@ def _infer_column(data) -> Union[ta.BaseColumn, Unresolved, None]:
 
         else:
             type_ = {
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 int: ta.VeloxType_BIGINT(),
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 float: ta.VeloxType_REAL(),
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 str: ta.VeloxType_VARCHAR(),
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 bool: ta.VeloxType_BOOLEAN(),
             }.get(type(non_null_item))
             if type_ is None:
                 raise NotImplementedError(f"Cannot infer {type(non_null_item)}")
             else:
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 col = ta.Column(type_)
                 for item in data:
                     if item is None:
@@ -603,17 +631,22 @@ def _infer_column(data) -> Union[ta.BaseColumn, Unresolved, None]:
 
 
 def resolve_column(item, type_) -> ta.BaseColumn:
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     col = ta.Column(type_)
     for value in item:
         if value is None:
             col.append_null()
         else:
             if type(type_) in (
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 ta.VeloxType_INTEGER,
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 ta.VeloxType_VARCHAR,
+                # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
                 ta.VeloxType_BOOLEAN,
             ):
                 col.append(value)
+            # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
             elif type(type_) == ta.VeloxArrayType:
                 col.append(resolve_column(value, type_.element_type()))
             else:

--- a/torcharrow/test/lib_test/test_udf.py
+++ b/torcharrow/test/lib_test/test_udf.py
@@ -4,11 +4,13 @@
 import unittest
 from typing import List, Any
 
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 # @manual=//pytorch/torcharrow/csrc/velox:_torcharrow
 import torcharrow._torcharrow as ta
 
 
 class TestSimpleColumns(unittest.TestCase):
+    # pyre-fixme[11]: Annotation `BaseColumn` is not defined as a type.
     def assert_SimpleColumn(self, col: ta.BaseColumn, val: List[Any]):
         self.assertEqual(len(col), len(val))
         for i in range(len(val)):
@@ -23,6 +25,7 @@ class TestSimpleColumns(unittest.TestCase):
 
     @staticmethod
     def construct_simple_column(velox_type, data: List[Any]):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         col = ta.Column(velox_type)
         for item in data:
             if item is None:

--- a/torcharrow/test/test_arrow_interop.py
+++ b/torcharrow/test/test_arrow_interop.py
@@ -50,6 +50,7 @@ class TestArrowInterop(unittest.TestCase):
         self, pydata: List, arrow_type: pa.DataType, expected_dtype: dt.DType
     ):
         s = pa.array(pydata, type=arrow_type)
+        # pyre-fixme[16]: `TestArrowInterop` has no attribute `device`.
         t = ta.from_arrow(s, device=self.device)
         self.assertFalse(isinstance(t, IDataFrame))
         expected_dtype = expected_dtype.with_null(nullable=s.null_count > 0)
@@ -180,9 +181,12 @@ class TestArrowInterop(unittest.TestCase):
     def _test_to_arrow_array_numeric(
         self, pydata: List, dtype: dt.DType, expected_arrowtype: pa.DataType
     ):
+        # pyre-fixme[16]: `TestArrowInterop` has no attribute `device`.
         t = ta.Column(pydata, dtype=dtype, device=self.device)
         s = t.to_arrow()
         self.assertTrue(isinstance(s, type(pa.array([], type=expected_arrowtype))))
+        # pyre-fixme[16]: Item `Array` of `Union[Array[typing.Any], ChunkedArray]`
+        #  has no attribute `type`.
         self.assertEqual(s.type, expected_arrowtype)
         for pa_val, ta_val in zip(s.to_pylist(), list(t)):
             if pa_val and math.isnan(pa_val) and ta_val and math.isnan(ta_val):

--- a/torcharrow/test/test_dtypes.py
+++ b/torcharrow/test/test_dtypes.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow as velox
 from torcharrow.dtypes import (
     Field,

--- a/torcharrow/test/test_functional_cpu.py
+++ b/torcharrow/test/test_functional_cpu.py
@@ -2,6 +2,8 @@
 import unittest
 
 import torcharrow as ta
+
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow
 import torcharrow.dtypes as dt
 from torcharrow import functional

--- a/torcharrow/test/test_interop.py
+++ b/torcharrow/test/test_interop.py
@@ -275,9 +275,7 @@ class TestInterop(unittest.TestCase):
         ):
             tensors = df[1:4].to_tensor(
                 {
-                    "dense_int8": tap.rec.Dense(  # pyre-ignore
-                        with_presence=True, batch_first=True
-                    ),
+                    "dense_int8": tap.rec.Dense(with_presence=True, batch_first=True),
                     "dense_int16": tap.rec.Dense(),
                     "dense_int32": tap.rec.Dense(),
                     "dense_int64": tap.rec.Dense(),
@@ -302,8 +300,10 @@ class TestInterop(unittest.TestCase):
         from torcharrow.pytorch import WithPresence, PackedList, PackedMap
 
         def list_plus_one(x: PackedList[WithPresence[torch.Tensor]]):
+            # pyre-fixme[16]: Module `pytorch` has no attribute `PackedList`.
             return PackedList(
                 offsets=x.offsets,
+                # pyre-fixme[16]: Module `pytorch` has no attribute `WithPresence`.
                 values=WithPresence(
                     presence=x.values.presence,
                     values=(x.values.values + 1) * x.values.presence,

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -565,6 +565,7 @@ class TestNumericalColumn(unittest.TestCase):
         data: ty.Iterable[ty.Union[int, float]],
         validation: ty.Callable = lambda x: x,
     ):
+        # pyre-fixme[16]: `TestNumericalColumn` has no attribute `device`.
         col_from = ta.Column(data, device=self.device, dtype=from_type)
         col_casted = col_from.cast(to_type)
         self.assertEqual(list(col_casted), [validation(d) for d in data])

--- a/torcharrow/velox_rt/__init__.py
+++ b/torcharrow/velox_rt/__init__.py
@@ -5,6 +5,8 @@ from .list_column_cpu import *
 from .map_column_cpu import *
 from .dataframe_cpu import *
 import torcharrow
+
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow
 
 # Initialize and register Velox functional

--- a/torcharrow/velox_rt/column.py
+++ b/torcharrow/velox_rt/column.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import typing as ty
 
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow as velox
 from torcharrow.dispatcher import Device
 from torcharrow.dtypes import DType
@@ -8,7 +9,9 @@ from torcharrow.icolumn import IColumn
 from torcharrow.scope import Scope
 
 # TODO: Rename this class to IColumnVelox or IColumnCpu
+# pyre-fixme[13]: Attribute `_finalized` is never initialized.
 class ColumnFromVelox:
+    # pyre-fixme[11]: Annotation `BaseColumn` is not defined as a type.
     _data: velox.BaseColumn
     _finalized: bool
 
@@ -28,11 +31,19 @@ class ColumnFromVelox:
     # This help method allows to alter it based on context (e.g. methods in IStringMethods can have better inference)
     def _with_null(self, nullable: bool):
         return self._from_velox(
-            self.device, self.dtype.with_null(nullable), self._data, True
+            # pyre-fixme[16]: `ColumnFromVelox` has no attribute `device`.
+            # pyre-fixme[16]: `ColumnFromVelox` has no attribute `dtype`.
+            self.device,
+            # pyre-fixme[16]: `ColumnFromVelox` has no attribute `dtype`.
+            self.dtype.with_null(nullable),
+            self._data,
+            True,
         )
 
     def _concat_with(self, columns: ty.List[IColumn]):
+        # pyre-fixme[16]: `ColumnFromVelox` has no attribute `to_pylist`.
         concat_list = self.to_pylist()
         for column in columns:
             concat_list += column.to_pylist()
+        # pyre-fixme[16]: `ColumnFromVelox` has no attribute `dtype`.
         return Scope._FromPySequence(concat_list, self.dtype)

--- a/torcharrow/velox_rt/functional.py
+++ b/torcharrow/velox_rt/functional.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import types
 
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow as ta
 from torcharrow._functional import functional as global_functional
 

--- a/torcharrow/velox_rt/map_column_cpu.py
+++ b/torcharrow/velox_rt/map_column_cpu.py
@@ -5,6 +5,8 @@ from typing import List
 
 import numpy as np
 import torcharrow as ta
+
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as pytorch

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -5,6 +5,8 @@ from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torcharrow as ta
+
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as pytorch
@@ -25,6 +27,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     """A Numerical Column on Velox backend"""
 
     # private
+    # pyre-fixme[11]: Annotation `BaseColumn` is not defined as a type.
     def __init__(self, device, dtype, data: velox.BaseColumn):
         assert dt.is_boolean_or_numerical(dtype)
         INumericalColumn.__init__(self, device, dtype)
@@ -42,6 +45,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     def _from_pysequence(
         device: str, data: Sequence[Union[int, float, bool]], dtype: dt.DType
     ):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         velox_column = velox.Column(get_velox_type(dtype), data)
         return ColumnFromVelox._from_velox(
             device,
@@ -61,8 +65,10 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         ptr_schema = int(ffi.cast("uintptr_t", c_schema))
         c_array = ffi.new("struct ArrowArray*")
         ptr_array = int(ffi.cast("uintptr_t", c_array))
+        # pyre-fixme[16]: `Array` has no attribute `_export_to_c`.
         array._export_to_c(ptr_array, ptr_schema)
 
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         velox_column = velox._import_from_arrow(
             get_velox_type(dtype), ptr_array, ptr_schema
         )
@@ -173,6 +179,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
                 res.append(self._getdata(i))
         res.sort(reverse=not ascending)
 
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         col = velox.Column(get_velox_type(self.dtype))
         if na_position == "first":
             for i in range(none_count):
@@ -287,6 +294,8 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __add__(self, other: Union[INumericalColumn, int, float]) -> INumericalColumn:
+        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
+        #  `Union[INumericalColumn, float, int]`.
         return self._checked_arithmetic_op_call(other, "add", operator.add)
 
     @trace
@@ -299,6 +308,8 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __sub__(self, other: Union[INumericalColumn, int, float]) -> INumericalColumn:
+        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
+        #  `Union[INumericalColumn, float, int]`.
         return self._checked_arithmetic_op_call(other, "sub", operator.sub)
 
     @trace
@@ -311,6 +322,8 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __mul__(self, other: Union[INumericalColumn, int, float]) -> INumericalColumn:
+        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
+        #  `Union[INumericalColumn, float, int]`.
         return self._checked_arithmetic_op_call(other, "mul", operator.mul)
 
     @trace
@@ -398,6 +411,8 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
               if a is float type, a % 0 will be float('nan')
         """
         return self._rethrow_zero_division_error(
+            # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but
+            #  got `Union[INumericalColumn, float, int]`.
             lambda: self._checked_arithmetic_op_call(other, "mod", operator.mod)
         )
 
@@ -471,6 +486,8 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __and__(self, other: Union[INumericalColumn, int]) -> INumericalColumn:
+        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
+        #  `Union[INumericalColumn, int]`.
         return self._checked_arithmetic_op_call(other, "bitwise_and", operator.__and__)
 
     @trace
@@ -483,6 +500,8 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __or__(self, other: Union[INumericalColumn, int]) -> INumericalColumn:
+        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
+        #  `Union[INumericalColumn, int]`.
         return self._checked_arithmetic_op_call(other, "bitwise_or", operator.__or__)
 
     @trace
@@ -495,6 +514,8 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
     @trace
     @expression
     def __xor__(self, other: Union[INumericalColumn, int]) -> INumericalColumn:
+        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
+        #  `Union[INumericalColumn, int]`.
         return self._checked_arithmetic_op_call(other, "bitwise_xor", operator.__xor__)
 
     @trace
@@ -593,6 +614,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         if not self.is_nullable:
             return self
         else:
+            # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
             col = velox.Column(get_velox_type(self.dtype))
             for i in range(len(self)):
                 if self._getmask(i):
@@ -631,6 +653,7 @@ class NumericalColumnCpu(ColumnFromVelox, INumericalColumn):
         if subset is not None:
             raise TypeError(f"subset parameter for numerical columns not supported")
         seen = set()
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         col = velox.Column(get_velox_type(self.dtype))
         for i in range(len(self)):
             if self._getmask(i):

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -3,6 +3,8 @@ import array as ar
 from typing import Optional, Sequence
 
 import numpy as np
+
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 from tabulate import tabulate
@@ -69,6 +71,7 @@ class StringColumnCpu(ColumnFromVelox, IStringColumn):
 
     @staticmethod
     def _from_pysequence(device: str, data: Sequence[str], dtype: dt.DType):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         velox_column = velox.Column(get_velox_type(dtype), data)
         return ColumnFromVelox._from_velox(
             device,

--- a/torcharrow/velox_rt/typing.py
+++ b/torcharrow/velox_rt/typing.py
@@ -1,38 +1,51 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import typing as ty
 
+# pyre-fixme[21]: Could not find module `torcharrow._torcharrow`.
 import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 
 # ------------------------------------------------------------------------------
 
 
+# pyre-fixme[11]: Annotation `VeloxType` is not defined as a type.
 def get_velox_type(dtype: dt.DType) -> velox.VeloxType:
     underlying_dtype = dt.get_underlying_dtype(dtype)
     if underlying_dtype == dt.int64:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxType_BIGINT()
     elif underlying_dtype == dt.int32:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxType_INTEGER()
     elif underlying_dtype == dt.int16:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxType_SMALLINT()
     elif underlying_dtype == dt.int8:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxType_TINYINT()
     elif underlying_dtype == dt.float32:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxType_REAL()
     elif underlying_dtype == dt.float64:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxType_DOUBLE()
     elif underlying_dtype == dt.string:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxType_VARCHAR()
     elif underlying_dtype == dt.boolean:
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxType_BOOLEAN()
     elif isinstance(underlying_dtype, dt.List):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxArrayType(get_velox_type(underlying_dtype.item_dtype))
     elif isinstance(underlying_dtype, dt.Map):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxMapType(
             get_velox_type(underlying_dtype.key_dtype),
             get_velox_type(underlying_dtype.item_dtype),
         )
     elif isinstance(underlying_dtype, dt.Struct):
+        # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
         return velox.VeloxRowType(
             [f.name for f in underlying_dtype.fields],
             [get_velox_type(f.dtype) for f in underlying_dtype.fields],
@@ -42,37 +55,51 @@ def get_velox_type(dtype: dt.DType) -> velox.VeloxType:
 
 
 def dtype_of_velox_type(vtype: velox.VeloxType) -> dt.DType:
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.BOOLEAN:
         return dt.Boolean(nullable=True)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.TINYINT:
         return dt.Int8(nullable=True)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.SMALLINT:
         return dt.Int16(nullable=True)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.INTEGER:
         return dt.Int32(nullable=True)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.BIGINT:
         return dt.Int64(nullable=True)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.REAL:
         return dt.Float32(nullable=True)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.DOUBLE:
         return dt.Float64(nullable=True)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.VARCHAR:
         return dt.String(nullable=True)
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.ARRAY:
         return dt.List(
             item_dtype=dtype_of_velox_type(
+                # pyre-fixme[11]: Annotation `VeloxArrayType` is not defined as a type.
                 ty.cast(velox.VeloxArrayType, vtype).element_type()
             ),
             nullable=True,
         )
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.MAP:
+        # pyre-fixme[11]: Annotation `VeloxMapType` is not defined as a type.
         vtype = ty.cast(velox.VeloxMapType, vtype)
         return dt.Map(
             key_dtype=dtype_of_velox_type(vtype.key_type()),
             item_dtype=dtype_of_velox_type(vtype.value_type()),
             nullable=True,
         )
+    # pyre-fixme[16]: Module `torcharrow` has no attribute `_torcharrow`.
     if vtype.kind() == velox.TypeKind.ROW:
+        # pyre-fixme[11]: Annotation `VeloxRowType` is not defined as a type.
         vtype = ty.cast(velox.VeloxRowType, vtype)
         fields = [
             dt.Field(


### PR DESCRIPTION
Summary:
To align with Python modern code guidance and ensure quality of torcharrow codebase, follow instruction in https://www.internalfb.com/intern/wiki/Python/Type-annotations-in-python/Quick_Start_in_FBCode/ to add pyre.
The comments are generated by pyre-upgrade tool

Next I will create bootcamp tasks, add dashboards, and make a post to involve team to get these fixed.
Our end goal is to enable pyre-strict for all py files in torcharrow.

Reviewed By: wenleix, dracifer

Differential Revision: D34260986

