### PR TITLE
Fix 404 error on apt-get

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Install dependencies with APT
         run: |
+          sudo apt-get update
           sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
           libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
           libbz2-dev libgflags-dev libgtest-dev libgmock-dev libevent-dev \


### PR DESCRIPTION
Summary:
Some diffs today encountered OSS CI failure such as D34331208 and D34309997, error as
https://github.com/facebookresearch/torcharrow/runs/5243973470?check_suite_focus=true
```
Get:142 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 protobuf-compiler amd64 3.6.1.3-2ubuntu5 [27.6 kB]
Fetched 45.0 MB in 18s (2527 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/n/nvidia-settings/libxnvctrl0_470.57.01-0ubuntu0.20.04.2_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

Error hints and [community](https://github.com/actions/virtual-environments/issues/675) suggests this fix.

Differential Revision: D34334509

