### PR TITLE
IListColumn.list.slice support and test

### DIFF
--- a/torcharrow/ilist_column.py
+++ b/torcharrow/ilist_column.py
@@ -86,18 +86,18 @@ class IListMethods(abc.ABC):
 
         return me._vectorize(fun, me.dtype.item_dtype.with_null(me.dtype.nullable))
 
-    # pyre-fixme[9]: start has type `int`; used as `None`.
-    # pyre-fixme[9]: stop has type `int`; used as `None`.
-    def slice(self, start: int = None, stop: int = None) -> IListColumn:
-        """Slice sublist from each element in the column"""
-        self._parent._prototype_support_warning("list.slice")
+    def slice(self, start: int = 0, stop: Optional[int] = None) -> IListColumn:
+        """
+        Slice sublist from each element in the column
 
-        me = self._parent
-
-        def fun(i):
-            return i[start:stop]
-
-        return me._vectorize(fun, me.dtype)
+        Parameters
+        ----------
+        start - int, default 0
+            Start position for slice operation. Negative starting position is not supported yet.
+        start - int, optional
+            Stop position for slice operation. Negative stop position is not supported yet.
+        """
+        raise NotImplementedError
 
     def vmap(self, fun: Callable[[Column], Column]):
         """

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -6,7 +6,7 @@
 
 import array as ar
 import warnings
-from typing import List, Callable
+from typing import List, Callable, Optional
 
 import torcharrow as ta
 
@@ -15,6 +15,7 @@ import torcharrow._torcharrow as velox
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as pytorch
 from tabulate import tabulate
+from torcharrow._functional import functional
 from torcharrow.dispatcher import Dispatcher
 from torcharrow.icolumn import Column
 from torcharrow.ilist_column import IListColumn, IListMethods
@@ -226,6 +227,27 @@ class ListMethodsCpu(IListMethods):
 
     def __init__(self, parent: ListColumnCpu):
         super().__init__(parent)
+
+    def length(self):
+        return functional.cardinality(self._parent)._with_null(
+            self._parent.dtype.nullable
+        )
+
+    def slice(self, start: int = 0, stop: Optional[int] = None) -> IListColumn:
+        if start < 0:
+            raise NotImplementedError("Negative start position is not supported yet")
+
+        if stop is None:
+            return functional.slice(self._parent, start + 1, 2 ** 31 - 1)._with_null(
+                self._parent.dtype.nullable
+            )
+
+        if stop < 0:
+            raise NotImplementedError("Negative start position is not supported yet")
+
+        return functional.slice(self._parent, start + 1, stop - start)._with_null(
+            self._parent.dtype.nullable
+        )
 
     def vmap(self, fun: Callable[[Column], Column]):
         elements = ColumnFromVelox._from_velox(


### PR DESCRIPTION
Summary:
I think this is inspired by `Series.str.slice` in Pandas: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.slice.html.

But indeed very natrual to extend to list methods as well.

We should probably also support this as a very Pythonic syntax sugar:
```
col.str[0:5]
col.list[0:5]
```

Differential Revision: D33769962

