### PR TITLE
TA column add support for & and | expression

### DIFF
--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -89,6 +89,31 @@ inline void registerTorchArrowFunctions() {
   velox::registerFunction<torcharrow_pow_int, int64_t, int64_t, int64_t>(
       {"torcharrow_pow"});
 
+  // Bitwise
+  // only supporting int and bool, not float or double
+  velox::registerFunction<torcharrow_bitwiseand, bool, bool, bool>(
+      {"torcharrow_bitwiseand"});
+  velox::registerFunction<torcharrow_bitwiseand, int8_t, int8_t, int8_t>(
+      {"torcharrow_bitwiseand"});
+  velox::registerFunction<torcharrow_bitwiseand, int16_t, int16_t, int16_t>(
+      {"torcharrow_bitwiseand"});
+  velox::registerFunction<torcharrow_bitwiseand, int32_t, int32_t, int32_t>(
+      {"torcharrow_bitwiseand"});
+  velox::registerFunction<torcharrow_bitwiseand, int64_t, int64_t, int64_t>(
+      {"torcharrow_bitwiseand"});
+
+  velox::registerFunction<torcharrow_bitwiseor, bool, bool, bool>(
+      {"torcharrow_bitwiseor"});
+  velox::registerFunction<torcharrow_bitwiseor, int8_t, int8_t, int8_t>(
+      {"torcharrow_bitwiseor"});
+  velox::registerFunction<torcharrow_bitwiseor, int16_t, int16_t, int16_t>(
+      {"torcharrow_bitwiseor"});
+  velox::registerFunction<torcharrow_bitwiseor, int32_t, int32_t, int32_t>(
+      {"torcharrow_bitwiseor"});
+  velox::registerFunction<torcharrow_bitwiseor, int64_t, int64_t, int64_t>(
+      {"torcharrow_bitwiseor"});
+
+
   // Round
   velox::registerFunction<torcharrow_round, float, float>({"torcharrow_round"});
   velox::registerFunction<torcharrow_round, double, double>(

--- a/csrc/velox/functions/numeric_functions.h
+++ b/csrc/velox/functions/numeric_functions.h
@@ -157,4 +157,22 @@ struct torcharrow_round {
   }
 };
 
+template <typename T>
+struct torcharrow_bitwiseand {
+  template <typename TOutput, typename TInput = TOutput>
+  FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& a, const TInput& b) {
+    result = a & b;
+    return true;
+  }
+};
+
+template <typename T>
+struct torcharrow_bitwiseor {
+  template <typename TOutput, typename TInput = TOutput>
+  FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& a, const TInput& b) {
+    result = a | b;
+    return true;
+  }
+};
+
 } // namespace facebook::torcharrow::functions

--- a/csrc/velox/functions/tests/FunctionsTest.cpp
+++ b/csrc/velox/functions/tests/FunctionsTest.cpp
@@ -195,6 +195,80 @@ TEST_F(FunctionsTest, pow) {
       "Inf is outside the range of representable values of type int64");
 }
 
+TEST_F(FunctionsTest, bitwise_and) {
+  const std::vector<int64_t> a = {-3, -1, 0, 1, 3};
+  const std::vector<int64_t> b = {1, 2, 4, 6, 8};
+  const std::vector<int64_t> expected = {1, 2, 0, 0, 0};
+  assertExpression<int64_t>("torcharrow_bitwiseand(c0, c1)", a, b, expected);
+
+  assertExpression<int32_t>(
+      "torcharrow_bitwiseand(c0, c1)",
+      {-3, -1, 0, 1, 3},
+      {1, 2, 4, 6, 8},
+      {1, 2, 0, 0, 0});
+
+  assertExpression<int16_t>(
+      "torcharrow_bitwiseand(c0, c1)",
+      {-3, -1, 0, 1, 3},
+      {1, 2, 4, 6, 8},
+      {1, 2, 0, 0, 0});
+
+  assertExpression<int8_t>(
+      "torcharrow_bitwiseand(c0, c1)",
+      {-3, -1, 0, 1, 3},
+      {1, 2, 4, 6, 8},
+      {1, 2, 0, 0, 0});
+
+  assertExpression<bool>(
+      "torcharrow_bitwiseand(c0, c1)",
+      {true, false, true, false},
+      {true, true, false, false},
+      {true, false, false, false});
+
+  assertError<float>(
+      "torcharrow_bitwiseand(c0, c1)",
+      {1.2},
+      {-3.4},
+      "Cannot resolve function call: torcharrow_bitwiseand(REAL, REAL)");
+}
+
+TEST_F(FunctionsTest, bitwise_or) {
+  const std::vector<int64_t> a = {-3, -1, 0, 1, 3};
+  const std::vector<int64_t> b = {1, 2, 4, 6, 8};
+  const std::vector<int64_t> expected = {-3, -1, 4, 7, 11};
+  assertExpression<int64_t>("torcharrow_bitwiseor(c0, c1)", a, b, expected);
+
+  assertExpression<int32_t>(
+      "torcharrow_bitwiseor(c0, c1)",
+      {-3, -1, 0, 1, 3},
+      {1, 2, 4, 6, 8},
+      {-3, -1, 4, 7, 11});
+
+  assertExpression<int16_t>(
+      "torcharrow_bitwiseor(c0, c1)",
+      {-3, -1, 0, 1, 3},
+      {1, 2, 4, 6, 8},
+      {-3, -1, 4, 7, 11});
+
+  assertExpression<int8_t>(
+      "torcharrow_bitwiseor(c0, c1)",
+      {-3, -1, 0, 1, 3},
+      {1, 2, 4, 6, 8},
+      {-3, -1, 4, 7, 11});
+
+  assertExpression<bool>(
+      "torcharrow_bitwiseor(c0, c1)",
+      {true, false, true, false},
+      {true, true, false, false},
+      {true, true, true, false});
+
+  assertError<float>(
+      "torcharrow_bitwiseor(c0, c1)",
+      {1.2},
+      {-3.4},
+      "Cannot resolve function call: torcharrow_bitwiseor(REAL, REAL)");
+}
+
 TEST_F(FunctionsTest, round) {
   std::vector<double> doubles = {
       1.3, 2.3, 1.5, 2.5, 1.8, 2.8, -1.3, -2.3, -1.5, -2.5, -1.8, -2.8};
@@ -270,7 +344,8 @@ TEST_F(FunctionsTest, round) {
 
   std::vector<int32_t> ints2 = {4, 15, 25, 123, -4, -15, -25, -123};
   std::vector<int32_t> expectedInts2 = {0, 20, 20, 120, 0, -20, -20, -120};
-  assertExpression<int32_t>("torcharrow_round(c0, c1)", ints2, decimals3, expectedInts2);
+  assertExpression<int32_t>(
+      "torcharrow_round(c0, c1)", ints2, decimals3, expectedInts2);
 
   std::vector<float> limits = {NAN, INFINITY, -INFINITY};
   assertUnaryExpression<float>("torcharrow_round(c0)", limits, limits);


### PR DESCRIPTION
Summary:
to support & and | operator for columns.
the and / or functions were not defined in velox, so I am not sure if that's the most appropriate place to add the new arithmetic functions there.

Reviewed By: OswinC, vancexu

Differential Revision: D34056665

