### PR TITLE
zero-copy from_arrow conversion for Struct type

### DIFF
--- a/csrc/velox/_torcharrow.pyi
+++ b/csrc/velox/_torcharrow.pyi
@@ -2266,6 +2266,9 @@ def _import_from_arrow(arg0: VeloxType_BIGINT, arg1: int, arg2: int) -> SimpleCo
 @overload
 def _import_from_arrow(arg0: VeloxType_REAL, arg1: int, arg2: int) -> SimpleColumnREAL:
     pass
+@overload
+def _import_from_arrow(arg0: VeloxRowType, arg1: int, arg2: int) -> RowColumn:
+    pass
 def _populate_dense_features_nopresence(arg0: RowColumn, arg1: int) -> None:
     pass
 def factory_udf_dispatch(arg0: str, arg1: int) -> BaseColumn:

--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -18,6 +18,7 @@
 #include "bindings.h"
 #include "column.h"
 #include "functions/functions.h" // @manual=//pytorch/torcharrow/csrc/velox/functions:torcharrow_functions
+#include "tensor_conversion.h"
 #include "vector.h"
 #include "velox/buffer/StringViewBufferHolder.h"
 #include "velox/common/base/Exceptions.h"
@@ -25,7 +26,6 @@
 #include "velox/type/Type.h"
 #include "velox/vector/TypeAliases.h"
 #include "velox/vector/arrow/Bridge.h"
-#include "tensor_conversion.h"
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
@@ -74,7 +74,8 @@ velox::FlatVectorPtr<T> flatVectorFromPySequence(const PySequence& data) {
         // std::string onto the buffers it manages. We can teach
         // StringViewBufferHolder how to copy data from
         // pybind11::str/pybind11::object to skip one copy
-        rawData[i] = stringArena.getOwnedValue(data[i].template cast<std::string>());
+        rawData[i] =
+            stringArena.getOwnedValue(data[i].template cast<std::string>());
       } else {
         rawData[i] = data[i].template cast<T>();
       }
@@ -145,14 +146,16 @@ py::class_<SimpleColumn<T>, BaseColumn> declareSimpleType(
       "Column",
       [](std::shared_ptr<I> type,
          py::list data) -> std::unique_ptr<SimpleColumn<T>> {
-        return std::make_unique<SimpleColumn<T>>(flatVectorFromPySequence<T>(data));
+        return std::make_unique<SimpleColumn<T>>(
+            flatVectorFromPySequence<T>(data));
       });
   // Column construction from Python tuple
   m.def(
       "Column",
       [](std::shared_ptr<I> type,
          py::tuple data) -> std::unique_ptr<SimpleColumn<T>> {
-        return std::make_unique<SimpleColumn<T>>(flatVectorFromPySequence<T>(data));
+        return std::make_unique<SimpleColumn<T>>(
+            flatVectorFromPySequence<T>(data));
       });
 
   // Import/Export Arrow data
@@ -164,51 +167,50 @@ py::class_<SimpleColumn<T>, BaseColumn> declareSimpleType(
       kind == velox::TypeKind::SMALLINT || kind == velox::TypeKind::INTEGER ||
       kind == velox::TypeKind::BIGINT || kind == velox::TypeKind::REAL ||
       kind == velox::TypeKind::DOUBLE) {
-    // _torcharrow._import_from_arrow
-    m.def(
-        "_import_from_arrow",
-        [](std::shared_ptr<I> type, uintptr_t ptrArray, uintptr_t ptrSchema) {
-          ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
-          ArrowSchema* castedSchema = reinterpret_cast<ArrowSchema*>(ptrSchema);
-          VELOX_CHECK_NOT_NULL(castedArray);
-          VELOX_CHECK_NOT_NULL(castedSchema);
+  // _torcharrow._import_from_arrow
+  m.def(
+      "_import_from_arrow",
+      [](std::shared_ptr<I> type, uintptr_t ptrArray, uintptr_t ptrSchema) {
+        ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
+        ArrowSchema* castedSchema = reinterpret_cast<ArrowSchema*>(ptrSchema);
+        VELOX_CHECK_NOT_NULL(castedArray);
+        VELOX_CHECK_NOT_NULL(castedSchema);
 
-          auto column =
-              std::make_unique<SimpleColumn<T>>(velox::importFromArrowAsOwner(
-                  *castedSchema,
-                  *castedArray,
-                  TorchArrowGlobalStatic::rootMemoryPool()));
+        auto column =
+            std::make_unique<SimpleColumn<T>>(velox::importFromArrowAsOwner(
+                *castedSchema,
+                *castedArray,
+                TorchArrowGlobalStatic::rootMemoryPool()));
 
-          VELOX_CHECK(
-              column->type()->kind() == kind,
-              "Expected TypeKind is {} but Velox created {}",
-              velox::TypeTraits<kind>::name,
-              column->type()->kindName());
+        VELOX_CHECK(
+            column->type()->kind() == kind,
+            "Expected TypeKind is {} but Velox created {}",
+            velox::TypeTraits<kind>::name,
+            column->type()->kindName());
 
-          return column;
-        });
+        return column;
+      });
 
-    // _torcharrow.SimpleColumn<Type>._export_to_arrow
-    result.def(
-        "_export_to_arrow", [](SimpleColumn<T>& self, uintptr_t ptrArray) {
-          ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
-          VELOX_CHECK_NOT_NULL(castedArray);
+  // _torcharrow.SimpleColumn<Type>._export_to_arrow
+  result.def("_export_to_arrow", [](SimpleColumn<T>& self, uintptr_t ptrArray) {
+    ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
+    VELOX_CHECK_NOT_NULL(castedArray);
 
-          if (self.getOffset() != 0 ||
-              self.getLength() < self.getUnderlyingVeloxVector()->size()) {
-            // This is a slice. Make a copy of the slice and then export the
-            // slice to Arrow
-            velox::VectorPtr temp = vectorSlice(
-                *self.getUnderlyingVeloxVector(),
-                self.getOffset(),
-                self.getOffset() + self.getLength());
-            temp->setNullCount(self.getNullCount());
-            velox::exportToArrow(temp, *castedArray);
-          } else {
-            velox::exportToArrow(self.getUnderlyingVeloxVector(), *castedArray);
-          }
-        });
-  }
+    if (self.getOffset() != 0 ||
+        self.getLength() < self.getUnderlyingVeloxVector()->size()) {
+      // This is a slice. Make a copy of the slice and then export the
+      // slice to Arrow
+      velox::VectorPtr temp = vectorSlice(
+          *self.getUnderlyingVeloxVector(),
+          self.getOffset(),
+          self.getOffset() + self.getLength());
+      temp->setNullCount(self.getNullCount());
+      velox::exportToArrow(temp, *castedArray);
+    } else {
+      velox::exportToArrow(self.getUnderlyingVeloxVector(), *castedArray);
+    }
+  });
+      }
 
   return result;
 };
@@ -760,6 +762,28 @@ void declareRowType(py::module& m) {
   m.def("Column", [](std::shared_ptr<I> type) {
     return std::make_unique<RowColumn>(type);
   });
+  // _torcharrow._import_from_arrow
+  m.def(
+      "_import_from_arrow",
+      [](std::shared_ptr<I> type, uintptr_t ptrArray, uintptr_t ptrSchema) {
+        ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
+        ArrowSchema* castedSchema = reinterpret_cast<ArrowSchema*>(ptrSchema);
+        VELOX_CHECK_NOT_NULL(castedArray);
+        VELOX_CHECK_NOT_NULL(castedSchema);
+
+        auto column = std::make_unique<RowColumn>(velox::importFromArrowAsOwner(
+            *castedSchema,
+            *castedArray,
+            TorchArrowGlobalStatic::rootMemoryPool()));
+
+        VELOX_CHECK(
+            column->type()->kind() == velox::TypeKind::ROW,
+            "Expected TypeKind is {} but Velox created {}",
+            velox::TypeTraits<velox::TypeKind::ROW>::name,
+            column->type()->kindName());
+
+        return column;
+      });
 }
 
 PYBIND11_MODULE(_torcharrow, m) {
@@ -826,8 +850,7 @@ PYBIND11_MODULE(_torcharrow, m) {
               [](SimpleColumn<bool>& self, bool value) { self.append(value); },
               // explicitly disallow all conversions to bools; enabling
               // this allows `None` and floats to convert to bools
-              py::arg("value").noconvert()
-              )
+              py::arg("value").noconvert())
           .def(
               "append",
               [](SimpleColumn<bool>& self, BIGINTNativeType value) {
@@ -877,7 +900,8 @@ PYBIND11_MODULE(_torcharrow, m) {
       "_populate_dense_features_nopresence",
       [](const RowColumn& column, uintptr_t dataTensorPtr) {
         populateDenseFeaturesNoPresence(
-            std::dynamic_pointer_cast<velox::RowVector>(column.getUnderlyingVeloxVector()),
+            std::dynamic_pointer_cast<velox::RowVector>(
+                column.getUnderlyingVeloxVector()),
             column.getOffset(),
             column.getLength(),
             dataTensorPtr);

--- a/torcharrow/test/test_arrow_interop_cpu.py
+++ b/torcharrow/test/test_arrow_interop_cpu.py
@@ -28,6 +28,9 @@ class TestArrowInteropCpu(TestArrowInterop):
     def test_from_arrow_array_string(self):
         return self.base_test_from_arrow_array_string()
 
+    def test_from_arrow_struct_array_having_nulls(self):
+        return self.base_test_from_arrow_struct_array_having_nulls()
+
     def test_from_arrow_table(self):
         return self.base_test_from_arrow_table()
 


### PR DESCRIPTION
Summary:
Implemented zero-copy from_arrow conversion for Struct type, as a fix for:
https://github.com/facebookresearch/torcharrow/issues/147

Make _fromarrow support for Struct type a zero-copy interop, by integrating Velox's Arrow interop support.

Two notes:
1. In order for the zero-copy of Struct Array to complete, its field type needs to be primitive, as for other types like String, we still need to copy its data.

2. This diff is for converting from Arrow Struct Array. The Arrow Table to TA Dataframe is still implemented via zero-copy of columns and re-construction into TA Dataframe from those columns.

Reference for the cffi technique used to pass C++ pointers between Python and C++:
https://github.com/facebookresearch/torcharrow/wiki/Arrow-Velox-zero-copy-conversion

Reference for Arrow Struct Layout:
https://arrow.apache.org/docs/format/Columnar.html...

Differential Revision: D34492729

