### PR TITLE
Fix indexing on eager string columns.

### DIFF
--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -30,6 +30,51 @@ class TestStringColumn(unittest.TestCase):
         self.assertEqual(empty.null_count, 0)
         # self.assertEqual(empty._offsets[0], 0)
 
+    def base_test_indexing(self):
+        col = ta.column(
+            [None] * 3 + ["3", "4", "5"],
+            dtype=dt.String(nullable=True),
+            device=self.device,
+        )
+
+        # index
+        self.assertEqual(col[0], None)
+        self.assertEqual(col[-1], "5")
+
+        # slice
+
+        # continuous slice
+        # document this is broken, will fix in the next diff.
+        with self.assertRaises(AttributeError):
+            c = col[3 : len(col)]
+            self.assertEqual(len(col), 6)
+            self.assertEqual(len(c), 3)
+
+        # non continuous slice
+        # document this is broken, will fix in the next diff.
+        with self.assertRaises(AttributeError):
+            d = col[::2]
+            self.assertEqual(len(col), 6)
+            self.assertEqual(len(d), 3)
+
+        # slice has Python not Pandas semantics
+        # document this is broken, will fix in the next diff.
+        with self.assertRaises(AttributeError):
+            e = col[: len(col) - 1]
+            self.assertEqual(len(e), len(col) - 1)
+
+        # indexing via lists
+        # document this is broken, will fix in the next diff.
+        with self.assertRaises(TypeError):
+            f = col[[0, 1, 2]]
+            self.assertEqual(list(f), list(col[:3]))
+
+        # head/tail are special slices
+        # document this is broken, will fix in the next diff.
+        with self.assertRaises(AttributeError):
+            self.assertEqual(list(col.head(2)), [None, None])
+            self.assertEqual(list(col.tail(2)), [4, 5])
+
     def base_test_append_offsets(self):
         c = ta.column(dt.string, device=self.device)
         c = c.append(["abc", "de", "", "f"])

--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -45,35 +45,30 @@ class TestStringColumn(unittest.TestCase):
 
         # continuous slice
         # document this is broken, will fix in the next diff.
-        with self.assertRaises(AttributeError):
-            c = col[3 : len(col)]
-            self.assertEqual(len(col), 6)
-            self.assertEqual(len(c), 3)
+        c = col[3 : len(col)]
+        self.assertEqual(len(col), 6)
+        self.assertEqual(len(c), 3)
 
         # non continuous slice
         # document this is broken, will fix in the next diff.
-        with self.assertRaises(AttributeError):
-            d = col[::2]
-            self.assertEqual(len(col), 6)
-            self.assertEqual(len(d), 3)
+        d = col[::2]
+        self.assertEqual(len(col), 6)
+        self.assertEqual(len(d), 3)
 
         # slice has Python not Pandas semantics
         # document this is broken, will fix in the next diff.
-        with self.assertRaises(AttributeError):
-            e = col[: len(col) - 1]
-            self.assertEqual(len(e), len(col) - 1)
+        e = col[: len(col) - 1]
+        self.assertEqual(len(e), len(col) - 1)
 
         # indexing via lists
         # document this is broken, will fix in the next diff.
-        with self.assertRaises(TypeError):
-            f = col[[0, 1, 2]]
-            self.assertEqual(list(f), list(col[:3]))
+        f = col[[0, 1, 2]]
+        self.assertEqual(list(f), list(col[:3]))
 
         # head/tail are special slices
         # document this is broken, will fix in the next diff.
-        with self.assertRaises(AttributeError):
-            self.assertEqual(list(col.head(2)), [None, None])
-            self.assertEqual(list(col.tail(2)), [4, 5])
+        self.assertEqual(list(col.head(2)), [None, None])
+        self.assertEqual(list(col.tail(2)), ["4", "5"])
 
     def base_test_append_offsets(self):
         c = ta.column(dt.string, device=self.device)

--- a/torcharrow/test/test_string_column_cpu.py
+++ b/torcharrow/test/test_string_column_cpu.py
@@ -27,6 +27,9 @@ class TestStringColumnCpu(TestStringColumn):
     def test_empty(self):
         self.base_test_empty()
 
+    def test_indexing(self):
+        self.base_test_indexing()
+
     def test_append_offsets(self):
         self.base_test_append_offsets()
 

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -134,17 +134,6 @@ class StringColumnCpu(ColumnFromVelox, StringColumn):
     def _valid_mask(ct):
         raise np.full((ct,), False, dtype=np.bool8)
 
-    def _gets(self, indices):
-        data = self._data[indices]
-        mask = self._mask[indices]
-        return self._scope._FullColumn(data, self.dtype, self.device, mask)
-
-    def _slice(self, start, stop, step):
-        range = slice(start, stop, step)
-        return self._scope._FullColumn(
-            self._data[range], self.dtype, self.device, self._mask[range]
-        )
-
     # operators ---------------------------------------------------------------
     def __add__(self, other):
         if isinstance(other, StringColumnCpu):


### PR DESCRIPTION
Summary:
Remove broken implementation of StringColumnCpu.{_gets,_slice}. Now
uses the same code path as NumericalColumnCpu.

Reviewed By: wenleix

Differential Revision: D34624981

