### PR TITLE
Fix ccache permission issue

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -58,12 +58,13 @@ jobs:
       - name: Configure ccache
         run: |
           echo "$GITHUB_WORKSPACE"
-          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz -M 5G
+          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root ccache -sz -M 1G
+          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz -M 1G
 
       - name: Build and install folly and fmt
         # sudo doesn't preserve environment vairable; set it after sudo: https://stackoverflow.com/questions/8633461/how-to-keep-environment-variables-when-using-sudo/33183620#33183620
         run: |
-          sudo CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache scripts/setup-ubuntu.sh
+          sudo CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root scripts/setup-ubuntu.sh
 
       - name: Bulid TorchArrow
         run: |


### PR DESCRIPTION
`sudo` is used when build and install `folly/fmt`. So if it's a cold start ccache, it will create temporary folder with `sudo` and later process cannot write to it. 

We should avoid requiring sudo to install `folly/fmt`. But for now just to have different ccache folder for `sudo` and non-sudo.

```
ccache: error: Failed to create temporary file for /home/runner/work/torcharrow/torcharrow/.ccache/tmp/register_b.stdout: Permission denied
ccache: error: Failed to create temporary file for /home/runner/work/torcharrow/torcharrow/.ccache/f/a/e2b86e93124c09aab775c23c114fc3-15295092.o.tmp.stdout: Permission denied
```