### PR TITLE
zero-copy to_arrow conversion for Struct type

### DIFF
--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -101,6 +101,22 @@ velox::FlatVectorPtr<T> flatVectorFromPySequence(const PySequence& data) {
   return flatVector;
 }
 
+void exportColumnToArrow(BaseColumn& self, ArrowArray* castedArray) {
+  if (self.getOffset() != 0 ||
+      self.getLength() < self.getUnderlyingVeloxVector()->size()) {
+    // This is a slice. Make a copy of the slice and then export the
+    // slice to Arrow
+    velox::VectorPtr temp = vectorSlice(
+        *self.getUnderlyingVeloxVector(),
+        self.getOffset(),
+        self.getOffset() + self.getLength());
+    temp->setNullCount(self.getNullCount());
+    velox::exportToArrow(temp, *castedArray);
+  } else {
+    velox::exportToArrow(self.getUnderlyingVeloxVector(), *castedArray);
+  }
+}
+
 template <
     velox::TypeKind kind,
     typename D,
@@ -167,50 +183,39 @@ py::class_<SimpleColumn<T>, BaseColumn> declareSimpleType(
       kind == velox::TypeKind::SMALLINT || kind == velox::TypeKind::INTEGER ||
       kind == velox::TypeKind::BIGINT || kind == velox::TypeKind::REAL ||
       kind == velox::TypeKind::DOUBLE) {
-  // _torcharrow._import_from_arrow
-  m.def(
-      "_import_from_arrow",
-      [](std::shared_ptr<I> type, uintptr_t ptrArray, uintptr_t ptrSchema) {
-        ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
-        ArrowSchema* castedSchema = reinterpret_cast<ArrowSchema*>(ptrSchema);
-        VELOX_CHECK_NOT_NULL(castedArray);
-        VELOX_CHECK_NOT_NULL(castedSchema);
+    // _torcharrow._import_from_arrow
+    m.def(
+        "_import_from_arrow",
+        [](std::shared_ptr<I> type, uintptr_t ptrArray, uintptr_t ptrSchema) {
+          ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
+          ArrowSchema* castedSchema = reinterpret_cast<ArrowSchema*>(ptrSchema);
+          VELOX_CHECK_NOT_NULL(castedArray);
+          VELOX_CHECK_NOT_NULL(castedSchema);
 
-        auto column =
-            std::make_unique<SimpleColumn<T>>(velox::importFromArrowAsOwner(
-                *castedSchema,
-                *castedArray,
-                TorchArrowGlobalStatic::rootMemoryPool()));
+          auto column =
+              std::make_unique<SimpleColumn<T>>(velox::importFromArrowAsOwner(
+                  *castedSchema,
+                  *castedArray,
+                  TorchArrowGlobalStatic::rootMemoryPool()));
 
-        VELOX_CHECK(
-            column->type()->kind() == kind,
-            "Expected TypeKind is {} but Velox created {}",
-            velox::TypeTraits<kind>::name,
-            column->type()->kindName());
+          VELOX_CHECK(
+              column->type()->kind() == kind,
+              "Expected TypeKind is {} but Velox created {}",
+              velox::TypeTraits<kind>::name,
+              column->type()->kindName());
 
-        return column;
-      });
+          return column;
+        });
 
-  // _torcharrow.SimpleColumn<Type>._export_to_arrow
-  result.def("_export_to_arrow", [](SimpleColumn<T>& self, uintptr_t ptrArray) {
-    ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
-    VELOX_CHECK_NOT_NULL(castedArray);
+    // _torcharrow.SimpleColumn<Type>._export_to_arrow
+    result.def(
+        "_export_to_arrow", [](SimpleColumn<T>& self, uintptr_t ptrArray) {
+          ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
+          VELOX_CHECK_NOT_NULL(castedArray);
 
-    if (self.getOffset() != 0 ||
-        self.getLength() < self.getUnderlyingVeloxVector()->size()) {
-      // This is a slice. Make a copy of the slice and then export the
-      // slice to Arrow
-      velox::VectorPtr temp = vectorSlice(
-          *self.getUnderlyingVeloxVector(),
-          self.getOffset(),
-          self.getOffset() + self.getLength());
-      temp->setNullCount(self.getNullCount());
-      velox::exportToArrow(temp, *castedArray);
-    } else {
-      velox::exportToArrow(self.getUnderlyingVeloxVector(), *castedArray);
-    }
-  });
-      }
+          exportColumnToArrow(self, castedArray);
+        });
+  }
 
   return result;
 };
@@ -743,7 +748,13 @@ void declareRowType(py::module& m) {
       .def("slice", &RowColumn::slice)
       .def("set_length", &RowColumn::setLength)
       .def("set_null_at", &RowColumn::setNullAt)
-      .def("copy", &RowColumn::copy);
+      .def("copy", &RowColumn::copy)
+      .def("_export_to_arrow", [](RowColumn& self, uintptr_t ptrArray) {
+        ArrowArray* castedArray = reinterpret_cast<ArrowArray*>(ptrArray);
+        VELOX_CHECK_NOT_NULL(castedArray);
+
+        exportColumnToArrow(self, castedArray);
+      });
 
   using I = typename velox::TypeTraits<velox::TypeKind::ROW>::ImplType;
   py::class_<I, velox::Type, std::shared_ptr<I>>(

--- a/torcharrow/_interop.py
+++ b/torcharrow/_interop.py
@@ -223,4 +223,13 @@ def _dtype_to_arrowtype(t: dt.DType) -> pa.DataType:
         return pa.float64()
     elif underlying_dtype == dt.string:
         return pa.string()
+    elif dt.is_struct(underlying_dtype):
+        return pa.struct(
+            [
+                pa.field(
+                    f.name, _dtype_to_arrowtype(f.dtype), nullable=f.dtype.nullable
+                )
+                for f in t.fields
+            ]
+        )
     raise NotImplementedError(f"Unsupported DType to Arrow type: {str(t)}")

--- a/torcharrow/test/test_arrow_interop.py
+++ b/torcharrow/test/test_arrow_interop.py
@@ -288,9 +288,9 @@ class TestArrowInterop(unittest.TestCase):
     def base_test_to_arrow_table_with_struct(self):
         df = ta.dataframe(
             [
-                (1, (10, 11)),
-                (2, (20, 21)),
-                (3, (30, None)),
+                (1, (10, 11, "a")),
+                (2, (20, 21, "b")),
+                (3, (30, None, None)),
             ],
             dtype=dt.Struct(
                 [
@@ -301,6 +301,7 @@ class TestArrowInterop(unittest.TestCase):
                             [
                                 dt.Field("int_1", dt.int32),
                                 dt.Field("int_2", dt.Int32(nullable=True)),
+                                dt.Field("string_1", dt.String(nullable=True)),
                             ]
                         ),
                     ),
@@ -323,9 +324,9 @@ class TestArrowInterop(unittest.TestCase):
         self.assertEqual(
             pt[1].to_pylist(),
             [
-                {"int_1": 10, "int_2": 11},
-                {"int_1": 20, "int_2": 21},
-                {"int_1": 30, "int_2": None},
+                {"int_1": 10, "int_2": 11, "string_1": "a"},
+                {"int_1": 20, "int_2": 21, "string_1": "b"},
+                {"int_1": 30, "int_2": None, "string_1": None},
             ],
         )
 


### PR DESCRIPTION
Summary:
implemented zero-copy to_arrow conversion for Struct type, as a fix for:
https://github.com/facebookresearch/torcharrow/issues/147
Make _toarrow support for Struct type a zero-copy interop, by integrating Velox's Arrow interop support.

Reference for the cffi technique used to pass C++ pointers between Python and C++:
https://github.com/facebookresearch/torcharrow/wiki/Arrow-Velox-zero-copy-conversion
Reference for Arrow Struct Layout:
https://arrow.apache.org/docs/format/Columnar.html

Differential Revision: D34582704

