### PR TITLE
infer data type for interop.from_pysequence

### DIFF
--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -46,8 +46,12 @@ def from_pysequence(
 ) -> Column:
     """
     Convert Python sequence of scalars or containers to a TorchArrow Column/DataFrame.
+    If dtype is None, it will be automatically inferred from data when possible.
     """
-    # TODO(https://github.com/facebookresearch/torcharrow/issues/80) Infer dtype
+
+    if not dtype:
+        dtype = dt.infer_dtype_from_prefix(data)
+
     device = device or Scope.default.device
 
     # pyre-fixme[6]: For 2nd param expected `DType` but got `Optional[DType]`.

--- a/torcharrow/test/test_interop.py
+++ b/torcharrow/test/test_interop.py
@@ -114,6 +114,37 @@ class TestInterop(unittest.TestCase):
         self.assertEqual(df.dtype, df3.dtype)
         self.assertEqual(list(df), list(df3))
 
+    def base_test_from_pysequence(self):
+        ## test with no dtype, to infer
+        ## for input of list and/or tuple
+        col = ta.from_pysequence(data=[None, None, 5], device=self.device)
+        self.assertEqual(list(col), [None, None, 5])
+        self.assertEqual(col.dtype, dt.Int64(nullable=True))
+
+        col = ta.from_pysequence(data=[3, 4, 5], device=self.device)
+        self.assertEqual(list(col), [3, 4, 5])
+        self.assertEqual(col.dtype, dt.int64)
+
+        col = ta.from_pysequence(data=(3, 4, 5), device=self.device)
+        self.assertEqual(list(col), [3, 4, 5])
+        self.assertEqual(col.dtype, dt.int64)
+
+        # test with dtype
+        # for input of list and/or tuple
+        col = ta.from_pysequence(
+            data=[None, None, 5], dtype=dt.Int32(nullable=True), device=self.device
+        )
+        self.assertEqual(list(col), [None, None, 5])
+        self.assertEqual(col.dtype, dt.Int32(nullable=True))
+
+        col = ta.from_pysequence(data=[3, 4, 5], dtype=dt.int32, device=self.device)
+        self.assertEqual(list(col), [3, 4, 5])
+        self.assertEqual(col.dtype, dt.int32)
+
+        col = ta.from_pysequence(data=(3, 4, 5), dtype=dt.int32, device=self.device)
+        self.assertEqual(list(col), [3, 4, 5])
+        self.assertEqual(col.dtype, dt.int32)
+
     def base_test_pad_sequence(self):
         import torch
 

--- a/torcharrow/test/test_interop_cpu.py
+++ b/torcharrow/test/test_interop_cpu.py
@@ -23,6 +23,9 @@ class TestInteropCpu(TestInterop):
     def test_pad_sequence(self):
         return self.base_test_pad_sequence()
 
+    def test_from_pysequence(self):
+        return self.base_test_from_pysequence()
+
     @unittest.skipUnless(tap.available, "Requires PyTorch")
     def test_pytorch_transform(self):
         return self.base_test_pytorch_transform()


### PR DESCRIPTION
Summary: when calling interop.from_pysequence,  if dtype is not given then infer from the data.

Differential Revision: D34809276

