### PR TITLE
Support calling UDF with constant array

### DIFF
--- a/csrc/velox/CMakeLists.txt
+++ b/csrc/velox/CMakeLists.txt
@@ -63,6 +63,8 @@ pybind11_add_module(
   column.cpp
   tensor_conversion.h
   tensor_conversion.cpp
+  VariantToVector.h
+  VariantToVector.cpp
 )
 
 # TODO(linb): Need this to match with velox, however pybind11 requires "hidden" visibility

--- a/csrc/velox/VariantToVector.cpp
+++ b/csrc/velox/VariantToVector.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Forked from
+// https://github.com/facebookincubator/velox/blob/18aff402c2b5a070ef7ec3f33cde017e90c8aa8a/velox/parse/VariantToVector.cpp
+// since parse is not part of VELOX_MINIMAL
+
+#include "velox/parse/VariantToVector.h"
+#include "velox/buffer/StringViewBufferHolder.h"
+#include "velox/type/Variant.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::torcharrow {
+namespace {
+
+using namespace facebook::velox;
+
+template <TypeKind KIND>
+ArrayVectorPtr variantArrayToVectorImpl(
+    const std::vector<variant>& variantArray,
+    velox::memory::MemoryPool* pool) {
+  using T = typename TypeTraits<KIND>::NativeType;
+
+  // First generate internal arrayVector elements.
+  const size_t variantArraySize = variantArray.size();
+
+  // Allocate buffer and set all values to null by default.
+  BufferPtr arrayElementsBuffer =
+      AlignedBuffer::allocate<T>(variantArraySize, pool);
+  BufferPtr nulls =
+      AlignedBuffer::allocate<bool>(variantArraySize, pool, bits::kNullByte);
+
+  // Create array elements internal flat vector.
+  auto arrayElements = std::make_shared<FlatVector<T>>(
+      pool,
+      CppToType<T>::create(),
+      nulls,
+      variantArraySize,
+      std::move(arrayElementsBuffer),
+      std::vector<BufferPtr>());
+
+  // Populate internal array elements (flat vector).
+  for (vector_size_t i = 0; i < variantArraySize; i++) {
+    if (!variantArray[i].isNull()) {
+      // `getOwnedValue` copies the content to its internal buffers (in case of
+      // string/StringView); no-op for other primitive types.
+      arrayElements->set(i, T(variantArray[i].value<KIND>()));
+    }
+  }
+
+  // Create ArrayVector around the FlatVector containing array elements.
+  BufferPtr offsets = AlignedBuffer::allocate<vector_size_t>(1, pool, 0);
+  BufferPtr sizes = AlignedBuffer::allocate<vector_size_t>(1, pool, 0);
+
+  auto rawSizes = sizes->asMutable<vector_size_t>();
+  rawSizes[0] = variantArraySize;
+
+  return std::make_shared<ArrayVector>(
+      pool,
+      ARRAY(Type::create<KIND>()),
+      BufferPtr(nullptr),
+      1,
+      offsets,
+      sizes,
+      arrayElements,
+      0);
+}
+} // namespace
+
+ArrayVectorPtr variantArrayToVector(
+    const std::vector<variant>& variantArray,
+    velox::memory::MemoryPool* pool) {
+  if (variantArray.empty()) {
+    return variantArrayToVectorImpl<TypeKind::UNKNOWN>(variantArray, pool);
+  }
+
+  const auto elementType = variantArray.front().inferType();
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      variantArrayToVectorImpl, elementType->kind(), variantArray, pool);
+}
+
+} // namespace facebook::velox::core

--- a/csrc/velox/VariantToVector.h
+++ b/csrc/velox/VariantToVector.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Forked from
+// https://github.com/facebookincubator/velox/blob/18aff402c2b5a070ef7ec3f33cde017e90c8aa8a/velox/parse/VariantToVector.h
+// since parse is not part of VELOX_MINIMAL
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::torcharrow {
+
+// Converts a sequence of values from a variant array to an ArrayVector. The
+// output ArrayVector contains one single row, which contains the elements
+// extracted from the input variant vector.
+velox::ArrayVectorPtr variantArrayToVector(
+    const std::vector<velox::variant>& variantArray,
+    velox::memory::MemoryPool* pool);
+
+} // namespace facebook::velox::core

--- a/csrc/velox/bindings.h
+++ b/csrc/velox/bindings.h
@@ -16,8 +16,8 @@ namespace facebook::torcharrow {
 
 void declareUserDefinedBindings(pybind11::module& m);
 
-// Returns true if successfully produced a `velox::variant` `out` from `obj`,
+// Returns true if successfully produced a `velox::variant` with Opaque type `out` from `obj`,
 // false otherwise
-bool userDefinedPyToVariant(const pybind11::handle& obj, velox::variant& out);
+bool userDefinedPyToOpaque(const pybind11::handle& obj, velox::variant& out);
 
 } // namespace facebook::torcharrow

--- a/csrc/velox/column.h
+++ b/csrc/velox/column.h
@@ -596,11 +596,17 @@ class FlatColumn : public SimpleColumn<T> {};
 template <typename T>
 class ConstantColumn : public SimpleColumn<T> {
  public:
+  // For scalar type that ConstantVector can be created from variant
   ConstantColumn(velox::variant value, velox::vector_size_t size)
       : SimpleColumn<T>(velox::BaseVector::createConstant(
             value,
             size,
             TorchArrowGlobalStatic::rootMemoryPool())) {}
+
+  // Create from a Vector position
+  ConstantColumn(velox::VectorPtr vector, int index, velox::vector_size_t size)
+      : SimpleColumn<T>(
+            velox::BaseVector::wrapInConstant(size, index, vector)) {}
 };
 
 class ArrayColumn : public BaseColumn {

--- a/csrc/velox/register_bindings.cpp
+++ b/csrc/velox/register_bindings.cpp
@@ -15,7 +15,7 @@ namespace facebook::torcharrow {
 
 void declareUserDefinedBindings(py::module& m) {}
 
-bool userDefinedPyToVariant(const pybind11::handle& obj, velox::variant& out) {
+bool userDefinedPyToOpaque(const pybind11::handle& obj, velox::variant& out) {
   return false;
 }
 


### PR DESCRIPTION
Summary:
Used by recommendation UDFs (e.g. bucketize: https://github.com/facebookresearch/torcharrow/pull/242)

```
functional.bucketize(df["a"], [1.0, 2.0, 3.0, 5.0, 8.0, 10.0, 11.0])
```

Differential Revision: D34832372

