### PR TITLE
Remove isprintable from the public API

### DIFF
--- a/torcharrow/istring_column.py
+++ b/torcharrow/istring_column.py
@@ -112,15 +112,6 @@ class StringMethods(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def isprintable(self):
-        """
-        Returns True if all the characters are printable, otherwise False.
-
-        A string is a printable if each character of the string is printable.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def isalnum(self):
         """
         Return True if all characters in the string are alphanumeric (either

--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -102,7 +102,7 @@ class TestStringColumn(unittest.TestCase):
         self.assertEqual(list(c.str.split(".", 10)), [v.split(".", 10) for v in s])
 
     def base_test_string_categorization_methods(self):
-        # isalpha/isnumeric/isalnum/isdigit/isdecimal/isspace/islower/isupper/istitle/isprintable
+        # isalpha/isnumeric/isalnum/isdigit/isdecimal/isspace/islower/isupper/istitle
         self.assertEqual(
             list(
                 self.create_column(
@@ -178,23 +178,6 @@ class TestStringColumn(unittest.TestCase):
                 ).str.istitle()
             ),
             [True, False, True, False, False, False],
-        )
-        self.assertEqual(
-            list(
-                self.create_column(
-                    [
-                        "abc",
-                        "ABc",
-                        "Ab  c",
-                        " ",
-                        "",
-                        u"ab\u0000\u000D",
-                        u"\u0605bc",
-                        "re\t32",
-                    ],
-                ).str.isprintable()
-            ),
-            [True, True, True, True, True, False, False, False],
         )
 
     def base_test_concat(self):

--- a/torcharrow/velox_rt/string_column_cpu.py
+++ b/torcharrow/velox_rt/string_column_cpu.py
@@ -301,11 +301,6 @@ class StringMethodsCpu(StringMethods):
             self._parent.dtype.nullable
         )
 
-    def isprintable(self) -> StringColumn:
-        return functional.torcharrow_isprintable(self._parent)._with_null(
-            self._parent.dtype.nullable
-        )
-
     # Pattern matching related methods  -----------------------------------------------------
 
     def startswith(self, pat):


### PR DESCRIPTION
Summary:
Title. We'll keep the UDF but remove the public API to avoid unnecessary maintenance load, since the strategy for public API is to provide a subset of Pandas API

FB: See D34590283 (https://github.com/facebookresearch/torcharrow/commit/199d6efbdba87d826b42c31ed2ea262473640503)

Reviewed By: wenleix

Differential Revision: D34872398

