### PR TITLE
Update version in build_wheel.sh to 0.0.4

### DIFF
--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -49,7 +49,7 @@ setup_wheel_python() {
   conda activate "env$PYTHON_VERSION"
 }
 
-setup_build_version 0.0.2
+setup_build_version 0.0.4
 setup_wheel_python
 python setup.py clean
 if [[ "$(uname)" == Darwin ]]; then


### PR DESCRIPTION
PYPI provides 0.0.3: https://pypi.org/project/torcharrow/0.0.3.dev2/
So PYPI version will be preferred over the nightly build (still 0.0.2)