### PR TITLE
Remove gtest from deps

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,7 +56,7 @@ jobs:
           CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz -M 5G
 
       - name: Build and install other dependencies
-        run: CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache scripts/build_mac_dep.sh ranges_v3 googletest fmt double_conversion folly re2
+        run: CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache scripts/build_mac_dep.sh ranges_v3 fmt double_conversion folly re2
 
       - name: Bulid TorchArrow
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get update
           sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
           libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
-          libgtest-dev libgflags-dev libevent-dev libre2-dev
+          libgflags-dev libevent-dev libre2-dev
 
       # Based on https://github.com/facebookincubator/velox/blob/99429407c3d524e07b32b8b19a03aa7382f819cf/.circleci/config.yml#L114-L116
       - name: Configure ccache

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ On MacOS
 brew install --formula ninja cmake ccache icu4c boost gflags glog libevent
 
 # Build and install other dependencies
-scripts/build_mac_dep.sh ranges_v3 googletest fmt double_conversion folly re2
+scripts/build_mac_dep.sh ranges_v3 fmt double_conversion folly re2
 ```
 
 On Ubuntu (20.04 or later)
@@ -69,7 +69,7 @@ On Ubuntu (20.04 or later)
 # Install dependencies from APT
 apt install -y g++ cmake ccache ninja-build checkinstall \
     libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
-    libgtest-dev libgflags-dev libevent-dev libre2-dev
+    libgflags-dev libevent-dev libre2-dev
 # Build and install folly and fmt
 scripts/setup-ubuntu.sh
 ```

--- a/scripts/_setup-macos.sh
+++ b/scripts/_setup-macos.sh
@@ -103,11 +103,6 @@ function install_build_prerequisites {
   pip3 install --user cmake-format regex
 }
 
-function install_googletest {
-  github_checkout google/googletest release-1.10.0
-  cmake_install
-}
-
 function install_fmt {
   github_checkout fmtlib/fmt 7.1.3
   cmake_install -DFMT_TEST=OFF


### PR DESCRIPTION
GTest is added as a submodule in
https://github.com/facebookincubator/velox/pull/1298.

No longer need it as deps.