### PR TITLE
Build on Mac with development target 10.15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,12 +56,12 @@ jobs:
           CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz -M 5G
 
       - name: Build and install other dependencies
-        run: CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache scripts/build_mac_dep.sh ranges_v3 fmt double_conversion folly re2
+        run: MACOSX_DEPLOYMENT_TARGET=10.15 CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache scripts/build_mac_dep.sh ranges_v3 fmt double_conversion folly re2
 
       - name: Bulid TorchArrow
         run: |
           CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz
-          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache python setup.py develop
+          MACOSX_DEPLOYMENT_TARGET=10.15 CCACHE_DIR=$GITHUB_WORKSPACE/.ccache python setup.py develop
 
       - name: Print CCache Stats
         run: CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -s

--- a/.github/workflows/nightly-wheel.yml
+++ b/.github/workflows/nightly-wheel.yml
@@ -56,9 +56,9 @@ jobs:
           done
 
   macos-container:
-    runs-on: macos-11
+    runs-on: macos-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version:
           - 3.7
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build the wheel
         run: |
-          ./csrc/velox/velox/scripts/setup-macos.sh
+          MACOSX_DEPLOYMENT_TARGET=10.15 ./csrc/velox/velox/scripts/setup-macos.sh
           pip install wheel
           ./packaging/build_wheel.sh
           pip install delocate

--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -33,7 +33,7 @@ setup_build_version() {
 # Set some useful variables for OS X, if applicable
 setup_macos() {
   if [[ "$(uname)" == Darwin ]]; then
-    export CC=clang CXX=clang++
+    export MACOSX_DEPLOYMENT_TARGET=10.15 CC=clang CXX=clang++
   fi
 }
 


### PR DESCRIPTION
Other PyTorch domain libraries still publish wheels that supports 10.X (e.g. 10.9 or 10.15) 