### PR TITLE
Enable `CLANGFORMAT` for TorchArrow

### DIFF
--- a/csrc/velox/VariantToVector.cpp
+++ b/csrc/velox/VariantToVector.cpp
@@ -85,4 +85,4 @@ ArrayVectorPtr variantArrayToVector(
       variantArrayToVectorImpl, elementType->kind(), variantArray, pool);
 }
 
-} // namespace facebook::velox::core
+} // namespace facebook::torcharrow

--- a/csrc/velox/VariantToVector.h
+++ b/csrc/velox/VariantToVector.h
@@ -22,4 +22,4 @@ velox::ArrayVectorPtr variantArrayToVector(
     const std::vector<velox::variant>& variantArray,
     velox::memory::MemoryPool* pool);
 
-} // namespace facebook::velox::core
+} // namespace facebook::torcharrow

--- a/csrc/velox/bindings.h
+++ b/csrc/velox/bindings.h
@@ -16,8 +16,8 @@ namespace facebook::torcharrow {
 
 void declareUserDefinedBindings(pybind11::module& m);
 
-// Returns true if successfully produced a `velox::variant` with Opaque type `out` from `obj`,
-// false otherwise
+// Returns true if successfully produced a `velox::variant` with Opaque type
+// `out` from `obj`, false otherwise
 bool userDefinedPyToOpaque(const pybind11::handle& obj, velox::variant& out);
 
 } // namespace facebook::torcharrow

--- a/csrc/velox/column.cpp
+++ b/csrc/velox/column.cpp
@@ -8,8 +8,8 @@
 
 #include "column.h"
 #include <memory>
-#include "bindings.h"
 #include "VariantToVector.h"
+#include "bindings.h"
 
 #include "pybind11/numpy.h"
 #include "pybind11/stl.h"

--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -176,7 +176,6 @@ inline void registerTorchArrowFunctions() {
   velox::registerFunction<bucketize, int32_t, int64_t, velox::Array<int64_t>>(
       {"bucketize"});
 
-
   // List input
   velox::registerFunction<
       bucketize,

--- a/csrc/velox/functions/numeric_functions.h
+++ b/csrc/velox/functions/numeric_functions.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <cmath>
 #include <math.h>
+#include <cmath>
 #include <limits>
 #include "velox/functions/Udf.h"
 
@@ -160,7 +160,8 @@ struct torcharrow_round {
 template <typename T>
 struct torcharrow_bitwiseand {
   template <typename TOutput, typename TInput = TOutput>
-  FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& a, const TInput& b) {
+  FOLLY_ALWAYS_INLINE bool
+  call(TOutput& result, const TInput& a, const TInput& b) {
     result = a & b;
     return true;
   }
@@ -169,7 +170,8 @@ struct torcharrow_bitwiseand {
 template <typename T>
 struct torcharrow_bitwiseor {
   template <typename TOutput, typename TInput = TOutput>
-  FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& a, const TInput& b) {
+  FOLLY_ALWAYS_INLINE bool
+  call(TOutput& result, const TInput& a, const TInput& b) {
     result = a | b;
     return true;
   }

--- a/csrc/velox/functions/rec/tests/BucketizeTest.cpp
+++ b/csrc/velox/functions/rec/tests/BucketizeTest.cpp
@@ -22,8 +22,8 @@
 namespace facebook::velox {
 namespace {
 
-  using namespace facebook::velox::test;
-  
+using namespace facebook::velox::test;
+
 class BucketizeTest : public functions::test::FunctionBaseTest {
  protected:
   static void SetUpTestCase() {

--- a/csrc/velox/functions/tests/FunctionsTest.cpp
+++ b/csrc/velox/functions/tests/FunctionsTest.cpp
@@ -351,7 +351,7 @@ TEST_F(FunctionsTest, round) {
   assertUnaryExpression<float>("torcharrow_round(c0)", limits, limits);
 }
 
-TEST_F(FunctionsTest, not) {
+TEST_F(FunctionsTest, not ) {
   assertUnaryExpression<int8_t>(
       "torcharrow_not(c0)", {10, 11, -1, -34}, {-11, -12, 0, 33});
   assertUnaryExpression<int32_t>(

--- a/csrc/velox/tensor_conversion.h
+++ b/csrc/velox/tensor_conversion.h
@@ -19,7 +19,7 @@ namespace facebook::torcharrow {
 //
 // Similar to AT_DISPATCH_ALL_TYPES in PyTorch:
 // https://github.com/pytorch/pytorch/blob/8bf3179f6e3fc9d468ff34a891c081590cd2412c/aten/src/ATen/Dispatch.h#L211-L214
-#define VELOX_DYNAMIC_NUMERIC_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)      \
+#define VELOX_DYNAMIC_NUMERIC_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)     \
   [&]() {                                                                     \
     switch (typeKind) {                                                       \
       case ::facebook::velox::TypeKind::INTEGER: {                            \
@@ -52,7 +52,8 @@ namespace facebook::torcharrow {
   }()
 
 // Populate packed dense features into Tensor.
-// Packed dense features are represented in Velox output slice as struct with same numeric-typed fields
+// Packed dense features are represented in Velox output slice as struct with
+// same numeric-typed fields
 //
 // Tensor data is expected to be pre-allocated with correct size
 void populateDenseFeaturesNoPresence(

--- a/csrc/velox/vector.cpp
+++ b/csrc/velox/vector.cpp
@@ -29,7 +29,8 @@ velox::VectorPtr
 arrayVectorSlice(const velox::ArrayVector& src, int start, int end) {
   auto length = end - start;
   std::shared_ptr<const velox::Type> elementType = src.type();
-  auto result = velox::BaseVector::create(ARRAY(elementType), length, src.pool());
+  auto result =
+      velox::BaseVector::create(ARRAY(elementType), length, src.pool());
   auto ptr = result.get()->as<velox::ArrayVector>();
   if (length > 0) {
     ptr->setElements(vectorSlice(


### PR DESCRIPTION
Summary:
tsia. In this diff we enabled CLANGFORMAT linters and fixed raised complaints.

Differential Revision: D35449235

