### PR TITLE
Add vocab UDF from TorchText

### DIFF
--- a/csrc/velox/column.cpp
+++ b/csrc/velox/column.cpp
@@ -25,6 +25,7 @@
 
 #ifdef USE_TORCH
 #include "functions/text/gpt2_bpe_tokenizer.h" // @manual
+#include "functions/text/vocab.h" // @manual
 #endif
 
 namespace py = pybind11;
@@ -670,6 +671,13 @@ velox::variant pyToVariant(const pybind11::handle& obj) {
     return velox::variant::opaque(
         obj.cast<std::shared_ptr<functions::GPT2BPEEncoder>>());
   }
+
+  // handle vocab opaque type
+  if (py::isinstance<functions::Vocab>(obj)) {
+    return velox::variant::opaque(
+        obj.cast<std::shared_ptr<functions::Vocab>>());
+  }
+
 #endif
 
   // Recursively allocate lists

--- a/csrc/velox/functions/CMakeLists.txt
+++ b/csrc/velox/functions/CMakeLists.txt
@@ -33,6 +33,9 @@ if (USE_TORCH)
     text/regex.h
     text/regex.cpp
     text/bpe_tokenize.h
+    text/vocab.h
+    text/vocab.cpp
+    text/vocab_ops.h
     )
   list(
     APPEND

--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -17,6 +17,7 @@
 #include "string_functions.h"
 #ifdef USE_TORCH
 #include "text/bpe_tokenize.h" // @manual
+#include "text/vocab_ops.h" // @manual
 #endif
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/Re2Functions.h"
@@ -239,7 +240,12 @@ inline void registerTorchArrowFunctions() {
 
 #ifdef USE_TORCH
   // TorchText
-  // bpe_encode
+  velox::registerFunction<
+      lookup_indices,
+      velox::ArrayWriterT<int64_t>,
+      std::shared_ptr<Vocab>,
+      velox::Array<velox::Varchar>>({"lookup_indices"});
+
   velox::registerFunction<
       bpe_tokenize,
       velox::ArrayWriterT<int64_t>,

--- a/csrc/velox/functions/text/vocab.cpp
+++ b/csrc/velox/functions/text/vocab.cpp
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vocab.h" // @manual
+#include <torch/torch.h> // @manual
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+namespace facebook::torcharrow::functions {
+
+Vocab::Vocab(StringList tokens, const c10::optional<int64_t>& default_index)
+    : stoi_(MAX_VOCAB_SIZE, -1), default_index_{default_index} {
+  for (auto& token : tokens) {
+    // throw error if duplicate token is found
+    auto id = _find(c10::string_view{token});
+    TORCH_CHECK(
+        stoi_[id] == -1, "Duplicate token found in tokens list: " + token);
+
+    _add(std::move(token));
+  }
+}
+
+Vocab::Vocab(StringList tokens) : Vocab(std::move(tokens), {}) {}
+
+int64_t Vocab::__len__() const {
+  return itos_.size();
+}
+
+bool Vocab::__contains__(const c10::string_view& token) const {
+  int64_t id = _find(token);
+  if (stoi_[id] != -1) {
+    return true;
+  }
+  return false;
+}
+
+int64_t Vocab::__getitem__(const c10::string_view& token) const {
+  int64_t id = _find(token);
+  if (stoi_[id] != -1)
+    return stoi_[id];
+
+  // throw error if default_index_ is not set
+  TORCH_CHECK(
+      default_index_.has_value(),
+      "Token " + std::string(token) +
+          " not found and default index is not set");
+
+  // return default index if token is OOV
+  return default_index_.value();
+}
+
+void Vocab::set_default_index(c10::optional<int64_t> index) {
+  default_index_ = index;
+}
+
+c10::optional<int64_t> Vocab::get_default_index() const {
+  return default_index_;
+}
+
+void Vocab::append_token(std::string token) {
+  // throw error if token already exist in vocab
+  auto id = _find(c10::string_view{token});
+  TORCH_CHECK(
+      stoi_[id] == -1,
+      "Token " + token + " already exists in the Vocab with index: " +
+          std::to_string(stoi_[id]));
+
+  _add(std::move(token));
+}
+
+void Vocab::insert_token(std::string token, const int64_t& index) {
+  // throw error if index is not valid
+  TORCH_CHECK(
+      index >= 0 && index <= __len__(),
+      "Specified index " + std::to_string(index) +
+          " is out of bounds for vocab of size " + std::to_string(__len__()));
+
+  // throw error if token already present
+  TORCH_CHECK(!__contains__(token), "Token " + token + " not found in Vocab");
+
+  // need to offset all tokens greater than or equal index by 1
+  for (size_t i = index; i < __len__(); i++) {
+    stoi_[_find(c10::string_view{itos_[i]})] = i + 1;
+  }
+
+  stoi_[_find(c10::string_view{token})] = index;
+  itos_.insert(itos_.begin() + index, std::move(token));
+}
+
+std::string Vocab::lookup_token(const int64_t& index) {
+  // throw error if index is not valid
+  TORCH_CHECK(
+      index >= 0 && index < __len__(),
+      "Specified index " + std::to_string(index) +
+          " is out of bounds for vocab of size " + std::to_string(__len__()));
+
+  return itos_[index];
+}
+
+StringList Vocab::lookup_tokens(const std::vector<int64_t>& indices) {
+  // throw error if indices are not valid
+  for (size_t i = 0; i < indices.size(); i++) {
+    TORCH_CHECK(
+        indices[i] >= 0 && indices[i] < __len__(),
+        "Specified index " + std::to_string(indices[i]) + " at position " +
+            std::to_string(i) + " is out of bounds for vocab of size " +
+            std::to_string(__len__()));
+  }
+
+  std::vector<std::string> tokens(indices.size());
+  for (size_t i = 0; i < indices.size(); i++) {
+    tokens[i] = itos_[indices[i]];
+  }
+  return tokens;
+}
+
+std::vector<int64_t> Vocab::lookup_indices(
+    const std::vector<c10::string_view>& tokens) {
+  std::vector<int64_t> indices(tokens.size());
+  for (size_t i = 0; i < tokens.size(); i++) {
+    indices[i] = __getitem__(tokens[i]);
+  }
+  return indices;
+}
+
+std::unordered_map<std::string, int64_t> Vocab::get_stoi() const {
+  std::unordered_map<std::string, int64_t> stoi;
+  // construct tokens and index list
+  for (const auto& item : itos_) {
+    stoi[item] = __getitem__(c10::string_view{item});
+  }
+  return stoi;
+}
+
+StringList Vocab::get_itos() const {
+  return itos_;
+}
+
+int64_t _infer_lines(const std::string& file_path) {
+  int64_t num_lines = 0;
+  std::ifstream fin;
+  fin.open(file_path, std::ios::in);
+  TORCH_CHECK(fin.is_open(), "Cannot open input file " + file_path);
+
+  while (fin.ignore(std::numeric_limits<std::streamsize>::max(), '\n')) {
+    num_lines++;
+  }
+  return num_lines;
+}
+
+void parse_vocab_file_chunk(
+    const std::string& file_path,
+    size_t offset,
+    const int64_t start_line,
+    const int64_t end_line,
+    const std::shared_ptr<IndexDict>& counter) {
+  std::ifstream fin(file_path, std::ios::in);
+  TORCH_CHECK(fin.is_open(), "Cannot open input file " + file_path);
+
+  fin.seekg(offset);
+
+  for (int64_t i = start_line; i < end_line; i++) {
+    std::string token;
+    fin >> token;
+    fin >> std::ws;
+
+    if ((*counter).find(token) == (*counter).end()) {
+      (*counter)[token] = 1;
+    } else {
+      (*counter)[token] += 1;
+    }
+  }
+}
+
+void parse_raw_text_file_chunk(
+    const std::string& file_path,
+    size_t offset,
+    const int64_t start_line,
+    const int64_t end_line,
+    const std::shared_ptr<IndexDict>& counter,
+    torch::jit::script::Module& module) {
+  std::ifstream fin(file_path, std::ios::in);
+  TORCH_CHECK(fin.is_open(), "Cannot open input file " + file_path);
+
+  fin.seekg(offset);
+
+  std::string line;
+  for (int64_t i = start_line; i < end_line; i++) {
+    std::getline(fin, line);
+    auto token_list =
+        module.forward(std::vector<c10::IValue>({c10::IValue(line)})).toList();
+
+    for (size_t i = 0; i < token_list.size(); i++) {
+      c10::IValue token_ref = token_list.get(i);
+      std::string token = token_ref.toStringRef();
+
+      if ((*counter).find(token) == (*counter).end()) {
+        (*counter)[token] = 1;
+      } else {
+        (*counter)[token] += 1;
+      }
+    }
+  }
+}
+
+StringList _concat_tokens(
+    std::vector<std::shared_ptr<IndexDict>> chunk_counters,
+    const int64_t min_freq,
+    const int64_t num_lines,
+    const bool sort_tokens) {
+  TORCH_CHECK(
+      chunk_counters.size() > 0,
+      "There must be at least 1 chunk to concatenate!");
+
+  IndexDict tokens_freq;
+  StringList unique_tokens;
+  unique_tokens.reserve(num_lines);
+
+  // concatenate all counters
+  for (size_t i = 0; i < chunk_counters.size(); i++) {
+    auto& cur_counter = *chunk_counters[i];
+    for (const auto& item : cur_counter) {
+      int64_t cur_token_freq = item.second;
+      if (tokens_freq.find(item.first) != tokens_freq.end()) {
+        tokens_freq[item.first] += cur_token_freq;
+      } else {
+        tokens_freq[item.first] = cur_token_freq;
+      }
+
+      // add to tokens list only if all of the conditions are met:
+      // 1. token is not empty
+      // 2. we exceed min_freq for the first time
+      if (item.first.length() &&
+          tokens_freq[item.first] - cur_token_freq < min_freq &&
+          tokens_freq[item.first] >= min_freq) {
+        unique_tokens.push_back(item.first);
+      }
+    }
+  }
+
+  // create token freq pairs
+  std::vector<std::pair<std::string, int64_t>> token_freq_pairs;
+
+  for (std::string& token : unique_tokens) {
+    auto token_freq = tokens_freq[token];
+    token_freq_pairs.emplace_back(std::move(token), token_freq);
+  }
+  unique_tokens.clear();
+
+  // sort tokens by freq
+  if (sort_tokens) {
+    CompareTokens compare_tokens;
+    std::sort(token_freq_pairs.begin(), token_freq_pairs.end(), compare_tokens);
+  }
+
+  // update unique tokens with correct order
+  for (auto& token_freq_pair : token_freq_pairs) {
+    unique_tokens.emplace_back(std::move(token_freq_pair.first));
+  }
+
+  return unique_tokens;
+}
+
+VocabStates _serialize_vocab(const c10::intrusive_ptr<Vocab>& self) {
+  std::vector<int64_t> integers;
+  StringList strings = self->itos_;
+  std::vector<torch::Tensor> tensors;
+
+  if (self->default_index_.has_value()) {
+    integers.push_back(self->default_index_.value());
+  }
+
+  VocabStates states = std::make_tuple(
+      self->version_str_,
+      std::move(integers),
+      std::move(strings),
+      std::move(tensors));
+  return states;
+}
+
+c10::intrusive_ptr<Vocab> _deserialize_vocab(VocabStates states) {
+  auto state_size = std::tuple_size<decltype(states)>::value;
+  TORCH_CHECK(
+      state_size == 4,
+      "Expected deserialized Vocab to have 4 states but found " +
+          std::to_string(state_size) + " states");
+
+  auto& version_str = std::get<0>(states);
+  auto& integers = std::get<1>(states);
+  auto& strings = std::get<2>(states);
+  auto& tensors = std::get<3>(states);
+
+  // check tensors are empty
+  TORCH_CHECK(tensors.size() == 0, "Expected `tensors` states to be empty");
+
+  // throw error if version is not compatible
+  TORCH_CHECK(
+      version_str.compare("0.0.2") >= 0,
+      "Found unexpected version for serialized Vocab: " + version_str);
+
+  c10::optional<int64_t> default_index = {};
+  if (integers.size() > 0) {
+    default_index = integers[0];
+  }
+  return c10::make_intrusive<Vocab>(std::move(strings), default_index);
+}
+
+} // namespace facebook::torcharrow::functions

--- a/csrc/velox/functions/text/vocab.h
+++ b/csrc/velox/functions/text/vocab.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <c10/util/string_view.h>
+#include <torch/script.h>
+#include <algorithm>
+
+namespace facebook::torcharrow::functions {
+
+typedef std::vector<std::string> StringList;
+typedef ska_ordered::order_preserving_flat_hash_map<std::string, int64_t>
+    IndexDict;
+typedef std::tuple<
+    std::string,
+    std::vector<int64_t>,
+    std::vector<std::string>,
+    std::vector<torch::Tensor>>
+    VocabStates;
+
+// sorting using a custom object
+struct CompareTokens {
+  bool operator()(
+      const std::pair<std::string, int64_t>& a,
+      const std::pair<std::string, int64_t>& b) {
+    if (a.second == b.second) {
+      return a.first < b.first;
+    }
+    return a.second > b.second;
+  }
+};
+
+int64_t _infer_lines(const std::string& file_path);
+
+struct Vocab : torch::CustomClassHolder {
+  static const int32_t MAX_VOCAB_SIZE = 30000000;
+  int64_t unk_index_{};
+  std::vector<int32_t> stoi_;
+  const std::string version_str_ = "0.0.2";
+  StringList itos_;
+  c10::optional<int64_t> default_index_ = {};
+
+  // TODO: [can we remove this?] we need to keep this constructor, otherwise
+  // torch binding gets compilation error: no matching constructor for
+  // initialization of 'torchtext::Vocab'
+  explicit Vocab(StringList tokens);
+  explicit Vocab(
+      StringList tokens,
+      const c10::optional<int64_t>& default_index);
+  int64_t __len__() const;
+  int64_t __getitem__(const c10::string_view& token) const;
+  bool __contains__(const c10::string_view& token) const;
+  void set_default_index(c10::optional<int64_t> index);
+  c10::optional<int64_t> get_default_index() const;
+  void insert_token(std::string token, const int64_t& index);
+  void append_token(std::string token);
+  std::string lookup_token(const int64_t& index);
+  std::vector<std::string> lookup_tokens(const std::vector<int64_t>& indices);
+  std::vector<int64_t> lookup_indices(
+      const std::vector<c10::string_view>& tokens);
+  std::unordered_map<std::string, int64_t> get_stoi() const;
+  std::vector<std::string> get_itos() const;
+
+ protected:
+  uint32_t _hash(const c10::string_view& str) const {
+    uint32_t h = 2166136261;
+    for (size_t i = 0; i < str.size(); i++) {
+      h = h ^ uint32_t(uint8_t(str[i]));
+      h = h * 16777619;
+    }
+    return h;
+  }
+
+  uint32_t _find(const c10::string_view& w) const {
+    uint32_t stoi_size = stoi_.size();
+    uint32_t id = _hash(w) % stoi_size;
+    while (stoi_[id] != -1 && itos_[stoi_[id]] != w) {
+      id = (id + 1) % stoi_size;
+    }
+    return id;
+  }
+
+  void _add(std::string w) {
+    uint32_t h = _find(c10::string_view{w.data(), w.size()});
+    if (stoi_[h] == -1) {
+      itos_.emplace_back(std::move(w));
+      stoi_[h] = itos_.size() - 1;
+    }
+  }
+};
+
+VocabStates _serialize_vocab(const c10::intrusive_ptr<Vocab>& self);
+c10::intrusive_ptr<Vocab> _deserialize_vocab(VocabStates states);
+
+} // namespace facebook::torcharrow::functions

--- a/csrc/velox/functions/text/vocab_ops.h
+++ b/csrc/velox/functions/text/vocab_ops.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "velox/functions/Udf.h"
+#include "velox/type/Type.h"
+#include "vocab.h"
+
+namespace facebook::torcharrow::functions {
+template <typename T>
+struct lookup_indices {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      velox::exec::ArrayWriter<int64_t>& result,
+      const arg_type<std::shared_ptr<Vocab>>& vocab,
+      const arg_type<velox::Array<velox::Varchar>>& tokens) {
+    for (const auto& token : tokens) {
+      std::string token_str = token.value().str();
+      result.push_back(vocab->__getitem__(token_str));
+    }
+    return true;
+  }
+};
+} // namespace facebook::torcharrow::functions

--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -943,8 +943,62 @@ PYBIND11_MODULE(_torcharrow, m) {
 #else
   m.attr("__version__") = "dev";
 #endif
-
 #ifdef USE_TORCH
+  py::class_<functions::Vocab, c10::intrusive_ptr<functions::Vocab>>(m, "Vocab")
+      .def(py::init<functions::StringList, c10::optional<int64_t>>())
+      .def_readonly("itos_", &functions::Vocab::itos_)
+      .def_readonly("default_index_", &functions::Vocab::default_index_)
+      .def(
+          "__contains__",
+          [](c10::intrusive_ptr<functions::Vocab>& self,
+             const py::str& item) -> bool {
+            Py_ssize_t length;
+            const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
+            return self->__contains__(c10::string_view{buffer, (size_t)length});
+          })
+      .def(
+          "__getitem__",
+          [](c10::intrusive_ptr<functions::Vocab>& self,
+             const py::str& item) -> int64_t {
+            Py_ssize_t length;
+            const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
+            return self->__getitem__(c10::string_view{buffer, (size_t)length});
+          })
+      .def("insert_token", &functions::Vocab::insert_token)
+      .def("set_default_index", &functions::Vocab::set_default_index)
+      .def("get_default_index", &functions::Vocab::get_default_index)
+      .def("__len__", &functions::Vocab::__len__)
+      .def("append_token", &functions::Vocab::append_token)
+      .def("lookup_token", &functions::Vocab::lookup_token)
+      .def("lookup_tokens", &functions::Vocab::lookup_tokens)
+      .def(
+          "lookup_indices",
+          [](const c10::intrusive_ptr<functions::Vocab>& self,
+             const py::list& items) {
+            std::vector<int64_t> indices(items.size());
+            int64_t counter = 0;
+            for (const auto& item : items) {
+              Py_ssize_t length;
+              const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
+              indices[counter++] =
+                  self->__getitem__(c10::string_view{buffer, (size_t)length});
+            }
+            return indices;
+          })
+      .def("get_stoi", &functions::Vocab::get_stoi)
+      .def("get_itos", &functions::Vocab::get_itos)
+      .def(py::pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<functions::Vocab>& self)
+              -> functions::VocabStates {
+            return functions::_serialize_vocab(self);
+          },
+          // __setstate__
+          [](functions::VocabStates states)
+              -> c10::intrusive_ptr<functions::Vocab> {
+            return functions::_deserialize_vocab(states);
+          }));
+
   // text operator
   py::class_<
       functions::GPT2BPEEncoder,


### PR DESCRIPTION
Adding Vocab UDF to TorchArrow

Usage example:

```python
import torcharrow as ta
import torcharrow._torcharrow as _ta
from torcharrow import functional as F
tokens = ["<unk>", "Hello", "world", "How", "are", "you!"]
# 0 is the default index which is returned when OOV token is queried
vocab = _ta.Vocab(tokens, 0)
df = ta.dataframe(
    {
        "text": [["Hello", "world"], ["How", "are", "you!", "OOV"]]
    }
)
df["indices"] = F.lookup_indices(vocab, df["text"])
```



