### PR TITLE
apply import merging for fbcode/pytorch/torcharrow (1 of 1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from setuptools import Extension
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 ROOT_DIR = Path(__file__).parent.resolve()

--- a/torcharrow/__init__.py
+++ b/torcharrow/__init__.py
@@ -4,14 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from . import pytorch  # noqa
-from . import velox_rt  # noqa
+from . import pytorch, velox_rt  # noqa  # noqa
 from ._functional import functional
 from .icolumn import Column, column, concat, if_else  # noqa
 from .idataframe import DataFrame, dataframe, me  # noqa
 from .ilist_column import ListColumn  # noqa
 from .imap_column import MapColumn  # noqa
-from .interop import from_pysequence, from_arrow  # noqa
+from .interop import from_arrow, from_pysequence  # noqa
 from .inumerical_column import NumericalColumn  # noqa
 from .istring_column import StringColumn  # noqa
 

--- a/torcharrow/_interop.py
+++ b/torcharrow/_interop.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional, cast
+from typing import cast, List, Optional
 
 # Skipping analyzing 'numpy': found module but no type hints or library stubs
 import numpy as np  # type: ignore

--- a/torcharrow/_pytorch/common.py
+++ b/torcharrow/_pytorch/common.py
@@ -7,13 +7,13 @@
 import abc
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TypeVar, Generic, Union, List, Optional, Tuple, Callable
+from typing import Callable, Generic, List, Optional, Tuple, TypeVar, Union
 
 import torch  # type: ignore
 import torcharrow as ta
 import torcharrow.dtypes as dt
 from torcharrow import dtypes
-from torcharrow.dtypes import DType, is_struct, is_list, is_map
+from torcharrow.dtypes import DType, is_list, is_map, is_struct
 from torcharrow.scope import Scope
 from typing_extensions import final
 

--- a/torcharrow/dispatcher.py
+++ b/torcharrow/dispatcher.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple, Callable, Dict, ClassVar
+from typing import Callable, ClassVar, Dict, Tuple
 
 # ---------------------------------------------------------------------------
 # column factory (class methods only!)

--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -9,7 +9,7 @@ import inspect
 import re
 import typing as ty
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, replace, is_dataclass
+from dataclasses import dataclass, is_dataclass, replace
 
 import numpy as np
 import torcharrow._torcharrow

--- a/torcharrow/icolumn.py
+++ b/torcharrow/icolumn.py
@@ -13,7 +13,7 @@ import math
 import operator
 import typing as ty
 import warnings
-from collections import OrderedDict, defaultdict
+from collections import defaultdict, OrderedDict
 from typing import Callable
 
 import numpy as np

--- a/torcharrow/idataframe.py
+++ b/torcharrow/idataframe.py
@@ -11,21 +11,21 @@ import abc
 from typing import (
     Any,
     Callable,
+    Dict,
+    get_type_hints,
     Iterable,
     List,
-    Dict,
     Mapping,
     Optional,
     Sequence,
     Union,
-    get_type_hints,
 )
 
 import torcharrow as ta
 import torcharrow.dtypes as dt
 from torcharrow.dispatcher import Device
 
-from .expression import Var, eval_expression, expression
+from .expression import eval_expression, expression, Var
 from .icolumn import Column
 from .scope import Scope
 from .trace import trace, traceproperty

--- a/torcharrow/ilist_column.py
+++ b/torcharrow/ilist_column.py
@@ -9,7 +9,7 @@ import array as ar
 import builtins
 import functools
 from dataclasses import dataclass
-from typing import Optional, Callable
+from typing import Callable, Optional
 
 import numpy as np
 import torcharrow.dtypes as dt

--- a/torcharrow/inumerical_column.py
+++ b/torcharrow/inumerical_column.py
@@ -9,7 +9,7 @@ import math
 import operator
 import statistics
 from functools import partial
-from typing import List, Optional, Union, Callable
+from typing import Callable, List, Optional, Union
 
 import torcharrow.dtypes as dt
 from torcharrow.dispatcher import Device

--- a/torcharrow/scope.py
+++ b/torcharrow/scope.py
@@ -11,7 +11,7 @@ import warnings
 import torcharrow as ta
 import torcharrow.dtypes as dt
 
-from .dispatcher import Dispatcher, Device
+from .dispatcher import Device, Dispatcher
 from .trace import Trace, trace
 
 # ---------------------------------------------------------------------------

--- a/torcharrow/test/lib_test/test_column.py
+++ b/torcharrow/test/lib_test/test_column.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import unittest
 from dataclasses import dataclass
-from typing import Union, List, Any
+from typing import Any, List, Union
 
 import pyarrow as pa  # @manual=@/third-party:apache-arrow:apache-arrow-py
 import torcharrow._torcharrow as ta

--- a/torcharrow/test/lib_test/test_udf.py
+++ b/torcharrow/test/lib_test/test_udf.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from typing import List, Any
+from typing import Any, List
 
 import torcharrow._torcharrow as ta
 

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from typing import List, Optional, NamedTuple
+from typing import List, NamedTuple, Optional
 
 import numpy.testing
 import torcharrow as ta

--- a/torcharrow/test/test_dtypes.py
+++ b/torcharrow/test/test_dtypes.py
@@ -12,18 +12,18 @@ import torcharrow.dtypes as dt
 from torcharrow.dtypes import (
     Field,
     Int64,
+    int64,
+    is_int64,
+    is_list,
+    is_map,
+    is_numerical,
+    is_string,
+    is_struct,
     List,
     Map,
     String,
-    Struct,
-    int64,
-    is_list,
-    is_string,
-    is_numerical,
-    is_map,
-    is_int64,
-    is_struct,
     string,
+    Struct,
 )
 from torcharrow.velox_rt.typing import dtype_of_velox_type
 

--- a/torcharrow/test/test_expression.py
+++ b/torcharrow/test/test_expression.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from dataclasses import dataclass
 from typing import Any, Callable, List, Mapping, Optional, Sequence
 
-from torcharrow.expression import Call, Expression, GetAttr, Var, eval_expression
+from torcharrow.expression import Call, eval_expression, Expression, GetAttr, Var
 
 # -----------------------------------------------------------------------------
 

--- a/torcharrow/test/test_interop.py
+++ b/torcharrow/test/test_interop.py
@@ -318,7 +318,7 @@ class TestInterop(unittest.TestCase):
             device=self.device,
         )
 
-        from torcharrow.pytorch import WithPresence, PackedList
+        from torcharrow.pytorch import PackedList, WithPresence
 
         def list_plus_one(x: PackedList[WithPresence[torch.Tensor]]):
             # pyre-fixme[16]: Module `pytorch` has no attribute `PackedList`.

--- a/torcharrow/test/test_numerical_column.py
+++ b/torcharrow/test/test_numerical_column.py
@@ -7,7 +7,7 @@
 import statistics
 import typing as ty
 import unittest
-from math import ceil, floor, log, isnan
+from math import ceil, floor, isnan, log
 
 import numpy as np
 import numpy.testing

--- a/torcharrow/test/test_trace.py
+++ b/torcharrow/test/test_trace.py
@@ -385,7 +385,7 @@ class TestDataframeTrace(unittest.TestCase):
         stms = Scope.default.trace.statements()
 
         import torcharrow
-        from torcharrow.dtypes import Struct, Field, int64
+        from torcharrow.dtypes import Field, int64, Struct
 
         # TODO: fix this
         # s0 = Scope.default

--- a/torcharrow/trace.py
+++ b/torcharrow/trace.py
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import functools
-from typing import List, Tuple, Type, Optional
+from typing import List, Optional, Tuple, Type
 
-from .expression import Expression, Call, Var, GetAttr
+from .expression import Call, Expression, GetAttr, Var
 
 # -----------------------------------------------------------------------------
 # Trace state (part of a scope object)

--- a/torcharrow/velox_rt/dataframe_cpu.py
+++ b/torcharrow/velox_rt/dataframe_cpu.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
+    cast,
     Dict,
     Iterable,
     Iterator,
@@ -24,7 +25,6 @@ from typing import (
     Sequence,
     Tuple,
     Union,
-    cast,
 )
 
 import numpy as np

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -6,7 +6,7 @@
 
 import array as ar
 import warnings
-from typing import List, Callable, Optional
+from typing import Callable, List, Optional
 
 import torcharrow as ta
 import torcharrow._torcharrow as velox


### PR DESCRIPTION
Summary:
Applies new import merging and sorting from µsort v1.0.

When merging imports, µsort will make a best-effort to move associated
comments to match merged elements, but there are known limitations due to
the diynamic nature of Python and developer tooling. These changes should
not produce any dangerous runtime changes, but may require touch-ups to
satisfy linters and other tooling.

Note that µsort uses case-insensitive, lexicographical sorting, which
results in a different ordering compared to isort. This provides a more
consistent sorting order, matching the case-insensitive order used when
sorting import statements by module name, and ensures that "frog", "FROG",
and "Frog" always sort next to each other.

For details on µsort's sorting and merging semantics, see the user guide:
https://usort.readthedocs.io/en/stable/guide.html#sorting

Differential Revision: D35552952

