### PR TITLE
Fix col * df op in eager mode

### DIFF
--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -12,6 +12,7 @@ import torcharrow as ta
 import torcharrow.dtypes as dt
 from torcharrow import me
 from torcharrow.idataframe import DataFrame
+from torcharrow.velox_rt.dataframe_cpu import DataFrameCpu
 
 # run python3 -m unittest outside this directory to run all tests
 
@@ -576,6 +577,17 @@ class TestDataFrame(unittest.TestCase):
             list(l + k),
             [(0, 0.0), (2, 11.0), (5, 22.0), (7, 33.0)],
         )
+
+        # *
+        dfa = ta.dataframe(
+            {"a": [1.0, 2.0, 3.0], "b": [11.0, 22.0, 33.0]}, device=self.device
+        )
+        dfb = dfa["a"] * dfa
+        self.assertEqual(list(dfb), [(1.0, 11.0), (4.0, 44.0), (9.0, 99.0)])
+        self.assertTrue(isinstance(dfb, DataFrameCpu))
+
+        cola = ta.column([3, 4, 5], device=self.device)
+        self.assertEqual(list(dfa * cola), [(3.0, 33.0), (8.0, 88.0), (15.0, 165.0)])
 
     def base_test_python_comparison_ops(self):
         # Use a dtype of list to prevent fast path through numerical

--- a/torcharrow/velox_rt/numerical_column_cpu.py
+++ b/torcharrow/velox_rt/numerical_column_cpu.py
@@ -267,7 +267,10 @@ class NumericalColumnCpu(ColumnCpuMixin, NumericalColumn):
         return self._checked_binary_op_call(other, op_name)
 
     def _checked_arithmetic_op_call(
-        self, other: Union[int, float, bool], op_name: str, fallback_py_op: Callable
+        self,
+        other: Union[NumericalColumn, int, float, bool],
+        op_name: str,
+        fallback_py_op: Callable,
     ) -> NumericalColumn:
         def should_use_py_impl(
             self, other: Union[NumericalColumn, int, float, bool]
@@ -325,8 +328,6 @@ class NumericalColumnCpu(ColumnCpuMixin, NumericalColumn):
     @trace
     @expression
     def __sub__(self, other: Union[NumericalColumn, int, float]) -> NumericalColumn:
-        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
-        #  `Union[NumericalColumn, float, int]`.
         return self._checked_arithmetic_op_call(other, "sub", operator.sub)
 
     @trace
@@ -338,16 +339,20 @@ class NumericalColumnCpu(ColumnCpuMixin, NumericalColumn):
 
     @trace
     @expression
-    def __mul__(self, other: Union[NumericalColumn, int, float]) -> NumericalColumn:
-        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
-        #  `Union[NumericalColumn, float, int]`.
-        return self._checked_arithmetic_op_call(other, "mul", operator.mul)
+    def __mul__(
+        self, other: Union[DataFrameCpu, NumericalColumn, int, float]
+    ) -> Union[DataFrameCpu, NumericalColumn]:
+        return self._checked_arithmetic_op_call_with_df(
+            other, "mul", operator.mul, "__rmul__"
+        )
 
     @trace
     @expression
-    def __rmul__(self, other: Union[int, float]) -> NumericalColumn:
-        return self._checked_arithmetic_op_call(
-            other, "rmul", Column._swap(operator.mul)
+    def __rmul__(
+        self, other: Union[int, float]
+    ) -> Union[DataFrameCpu, NumericalColumn]:
+        return self._checked_arithmetic_op_call_with_df(
+            other, "rmul", Column._swap(operator.mul), "__mul__"
         )
 
     @trace
@@ -428,8 +433,6 @@ class NumericalColumnCpu(ColumnCpuMixin, NumericalColumn):
               if a is float type, a % 0 will be float('nan')
         """
         return self._rethrow_zero_division_error(
-            # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but
-            #  got `Union[NumericalColumn, float, int]`.
             lambda: self._checked_arithmetic_op_call(other, "mod", operator.mod)
         )
 
@@ -491,8 +494,6 @@ class NumericalColumnCpu(ColumnCpuMixin, NumericalColumn):
     @trace
     @expression
     def __and__(self, other: Union[NumericalColumn, int]) -> NumericalColumn:
-        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
-        #  `Union[NumericalColumn, int]`.
         return self._checked_arithmetic_op_call(other, "bitwise_and", operator.__and__)
 
     @trace
@@ -505,8 +506,6 @@ class NumericalColumnCpu(ColumnCpuMixin, NumericalColumn):
     @trace
     @expression
     def __or__(self, other: Union[NumericalColumn, int]) -> NumericalColumn:
-        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
-        #  `Union[NumericalColumn, int]`.
         return self._checked_arithmetic_op_call(other, "bitwise_or", operator.__or__)
 
     @trace
@@ -519,8 +518,6 @@ class NumericalColumnCpu(ColumnCpuMixin, NumericalColumn):
     @trace
     @expression
     def __xor__(self, other: Union[NumericalColumn, int]) -> NumericalColumn:
-        # pyre-fixme[6]: For 1st param expected `Union[bool, float, int]` but got
-        #  `Union[NumericalColumn, int]`.
         return self._checked_arithmetic_op_call(other, "bitwise_xor", operator.__xor__)
 
     @trace


### PR DESCRIPTION
Summary: tsia. In this diff we want to make the behavior more consistent in both eager and deferred mode for the column multiplies dataframe case.

Differential Revision: D35515660

