### PR TITLE
suppress errors in `fbcode/pytorch` - batch 2

### DIFF
--- a/torcharrow/_functional.py
+++ b/torcharrow/_functional.py
@@ -95,6 +95,8 @@ class _Functional(ModuleType):
     def register_factory_methods(self, methods):
         self._factory_methods.update(methods)
 
+    # pyre-fixme[14]: `__getattr__` overrides method defined in `ModuleType`
+    #  inconsistently.
     def __getattr__(self, op_name: str):
         wrapper = self.create_dispatch_wrapper(op_name)
         setattr(self, op_name, wrapper)

--- a/torcharrow/velox_rt/functional.py
+++ b/torcharrow/velox_rt/functional.py
@@ -68,6 +68,8 @@ class VeloxFunctional(types.ModuleType):
             return dispatch
 
     # TODO: automtically populate it
+    # pyre-fixme[14]: `__getattr__` overrides method defined in `ModuleType`
+    #  inconsistently.
     def __getattr__(self, op_name: str):
         dispatch_wrapper = self.create_dispatch_wrapper(op_name)
         setattr(self, op_name, dispatch_wrapper)


### PR DESCRIPTION
Summary:
Meta uses the Pyre typechecker on some projects with code included in
pytorch. Pyre is very strict about type errors, and as a result when upgrading
Pyre versions we need to run error suppression when new features cause Pyre
to find more potentially non-type-safe code.

This is one such Pyre error suppression pass. It will not affect pytorch at runtime
or the mypy typechecking used on Github.

Differential Revision: D35753873

