### PR TITLE
Debug constructing DataFrame from NamedTuple fails without dtype

### DIFF
--- a/torcharrow/scope.py
+++ b/torcharrow/scope.py
@@ -344,13 +344,21 @@ but data only provides {len(data)} fields: {data.keys()}
                 if dtype is None or not dt.is_tuple(dtype):
                     raise TypeError("Dataframe cannot infer struct type from data")
                 dtype = ty.cast(dt.Tuple, dtype)
-                if columns is None:
-                    raise TypeError(
-                        "DataFrame construction from tuples requires"
-                        " dtype or columns to be given"
-                    )
-                if len(dtype.fields) != len(columns):
-                    raise TypeError("Dataframe column length must equal row length")
+                if columns is not None:
+                    if len(dtype.fields) != len(columns):
+                        raise TypeError("Dataframe column length must equal row length")
+                else:
+                    first_tuple_columns = None
+                    for v in data:
+                        if v is not None:
+                            if hasattr(v, "_fields"):
+                                first_tuple_columns = v._fields
+                                break
+                    if first_tuple_columns is None:
+                        raise TypeError(
+                            "DataFrame construction from tuples requires dtype or columns to be given"
+                        )
+                    columns = list(first_tuple_columns)
                 dtype = dt.Struct(
                     [dt.Field(n, t) for n, t in zip(columns, dtype.fields)]
                 )


### PR DESCRIPTION
Summary: Updated the scope.py file. Changed the way to handle the situation when there is data without dtype or columns.

Reviewed By: hanqiwu0704

Differential Revision: D35823382

