### PR TITLE
Replace coalesce function with a special form (#1430)

### DIFF
--- a/csrc/velox/column.cpp
+++ b/csrc/velox/column.cpp
@@ -433,6 +433,11 @@ std::unique_ptr<OperatorHandle> OperatorHandle::fromCall(
 std::unique_ptr<OperatorHandle> OperatorHandle::fromUDF(
     velox::RowTypePtr inputRowType,
     const std::string& udfName) {
+  if (udfName == "coalesce") {
+    return OperatorHandle::fromCall(
+        inputRowType, inputRowType->childAt(0), udfName);
+  }
+
   velox::TypePtr outputType =
       velox::resolveFunction(udfName, inputRowType->children());
   if (outputType == nullptr) {


### PR DESCRIPTION
Summary:
Coalesce needs to be a special form expression and cannot be a function because
it is not supposed to evaluate remaining inputs once there are no nulls. For
example, if column a has no nulls, the following expression should not try to
evaluate `b / 0` and should not fail.

```
coalesce(a, b / 0)
```

This change introduces CoalesceExpr special form and deletes coalesce function.

Also, fix a crash due to null pointer dereference in FlatVector::mutableRawValues.

X-link: https://github.com/facebookincubator/velox/pull/1430

Differential Revision: D35674128

Pulled By: mbasmanova

