### PR TITLE
Velox basic firstX function

### DIFF
--- a/csrc/velox/functions/CMakeLists.txt
+++ b/csrc/velox/functions/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
   numeric_functions.h
   rec/bucketize.h
   rec/sigrid_hash.h
+  rec/firstX.h
   register_udf.cpp
 )
 

--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -11,6 +11,7 @@
 #include <velox/functions/Registerer.h>
 #include "numeric_functions.h"
 #include "rec/bucketize.h" // @manual
+#include "rec/firstX.h" // @manual
 #include "rec/sigrid_hash.h" // @manual
 #include "string_functions.h"
 #include "velox/expression/VectorFunction.h"
@@ -224,7 +225,7 @@ inline void registerTorchArrowFunctions() {
       velox::Array<int64_t>,
       velox::Array<int64_t>>({"bucketize"});
 
-  //   sigrid_hash
+  // sigrid_hash
   velox::registerFunction<sigrid_hash, int64_t, int64_t, int64_t, int64_t>(
       {"sigrid_hash"});
 
@@ -234,6 +235,31 @@ inline void registerTorchArrowFunctions() {
       velox::Array<int64_t>,
       int64_t,
       int64_t>({"sigrid_hash"});
+
+  // firstX
+  velox::registerFunction<
+      firstX,
+      velox::ArrayWriterT<int32_t>,
+      velox::Array<int32_t>,
+      int32_t>({"firstx"});
+
+  velox::registerFunction<
+      firstX,
+      velox::ArrayWriterT<int64_t>,
+      velox::Array<int64_t>,
+      int32_t>({"firstx"});
+
+  velox::registerFunction<
+      firstX,
+      velox::ArrayWriterT<int32_t>,
+      velox::Array<int32_t>,
+      int64_t>({"firstx"});
+
+  velox::registerFunction<
+      firstX,
+      velox::ArrayWriterT<int64_t>,
+      velox::Array<int64_t>,
+      int64_t>({"firstx"});
 
   // TODO: consider to refactor registration code with helper functions
   // to save some lines, like https://fburl.com/code/dk6zi7t3

--- a/csrc/velox/functions/rec/firstX.h
+++ b/csrc/velox/functions/rec/firstX.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <velox/functions/Macros.h>
+#include <algorithm>
+#include "velox/core/QueryConfig.h"
+#include "velox/expression/ComplexViewTypes.h"
+#include "velox/functions/Udf.h"
+#include "velox/type/Type.h"
+
+namespace facebook::torcharrow::functions {
+
+template <typename T>
+struct firstX {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TOutput, typename TInput>
+  FOLLY_ALWAYS_INLINE void
+  callNullFree(TOutput& result, TInput& input, const int32_t& numToCopy) {
+    int32_t actualNumToCopy = std::min(numToCopy, input.size());
+    for (auto i = 0; i < actualNumToCopy; i++) {
+      result.push_back(input[i]);
+    }
+  }
+};
+
+} // namespace facebook::torcharrow::functions

--- a/csrc/velox/functions/rec/tests/FirstXTest.cpp
+++ b/csrc/velox/functions/rec/tests/FirstXTest.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdint>
+#include <optional>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <velox/common/base/VeloxException.h>
+#include <velox/vector/SimpleVector.h>
+#include <velox/vector/tests/VectorTestBase.h>
+
+#include "pytorch/torcharrow/csrc/velox/functions/functions.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace facebook::velox {
+namespace {
+
+using namespace facebook::velox::test;
+
+class firstXTest : public functions::test::FunctionBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    torcharrow::functions::registerTorchArrowFunctions();
+  }
+};
+
+TEST_F(firstXTest, basicUsage) {
+  std::vector<std::vector<int64_t>> a = {{1, 2}, {3, 4}, {5, 6}};
+  std::vector<int32_t> b(a.size(), 1);
+
+  auto c0 = makeArrayVector(a);
+  auto c1 = makeFlatVector(b);
+  auto c = evaluate<ArrayVector>("firstx(c0, c1)", makeRowVector({c0, c1}));
+
+  std::vector<std::vector<int64_t>> expected = {{1}, {3}, {5}};
+  assertEqualVectors(makeArrayVector(expected), c);
+}
+
+} // namespace
+} // namespace facebook::velox

--- a/torcharrow/test/transformation/test_firstx.py
+++ b/torcharrow/test/transformation/test_firstx.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torcharrow as ta
+import torcharrow.dtypes as dt
+from torcharrow import functional
+
+
+class _TestFunctionalBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_df_list = ta.dataframe(
+            {
+                "a": [[0, 1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            },
+            dtype=dt.Struct(
+                fields=[
+                    dt.Field("a", dt.List(dt.int64)),
+                ]
+            ),
+        )
+
+        cls.setUpTestCaseData()
+
+    @classmethod
+    def setUpTestCaseData(cls):
+        # Override in subclass
+        # Python doesn't have native "abstract base test" support.
+        # So use unittest.SkipTest to skip in base class: https://stackoverflow.com/a/59561905.
+        raise unittest.SkipTest("abstract base test")
+
+    def test_firstx(self):
+        df = type(self).df_list
+
+        self.assertEqual(
+            list(functional.firstx(df["a"], 1)),
+            [[0], [4], [7]],
+        )
+
+        self.assertEqual(
+            list(functional.firstx(df["a"], 2)),
+            [[0, 1], [4, 5], [7, 8]],
+        )
+
+        self.assertEqual(
+            list(functional.firstx(df["a"], 4)),
+            [[0, 1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        )
+
+
+class TestFunctionalCpu(_TestFunctionalBase):
+    @classmethod
+    def setUpTestCaseData(cls):
+        cls.df_list = cls.base_df_list.copy()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
This diff implements a simple usecase of firstX. It supports simple inputs array of integers.

But actually this function should support two more use cases:
1. Array of arrays as input
2. Array of tuples (rows) as input

1 should have the same behavior, while 2 needs to go through a sorting before taking the truncation. I'll add those in followup diffs as they seem non-trivial for one diff.

Reviewed By: vancexu, YLGH

Differential Revision: D35977179

