### PR TITLE
Implement support for fixed length lists.

### DIFF
--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -558,7 +558,9 @@ py::class_<SimpleColumn<T>, BaseColumn> declareFloatingType(py::module& m) {
 template <
     velox::TypeKind kind,
     typename T = typename velox::TypeTraits<kind>::NativeType>
-velox::ArrayVectorPtr arrayVectorFromPyList(const py::list& data) {
+velox::ArrayVectorPtr arrayVectorFromPyList(
+    int fixed_size,
+    const py::list& data) {
   using velox::vector_size_t;
 
   // Prepare the arguments for creating ArrayVector
@@ -625,9 +627,13 @@ velox::ArrayVectorPtr arrayVectorFromPyList(const py::list& data) {
   }
   flatVector->setNullCount(elementNullCount);
 
+  const auto typ = fixed_size == -1
+      ? velox::ARRAY(velox::CppToType<T>::create())
+      : velox::FIXED_SIZE_ARRAY(fixed_size, velox::CppToType<T>::create());
+
   return std::make_shared<velox::ArrayVector>(
       TorchArrowGlobalStatic::rootMemoryPool(),
-      velox::ARRAY(velox::CppToType<T>::create()),
+      typ,
       nulls,
       data.size(),
       offsets,
@@ -637,6 +643,7 @@ velox::ArrayVectorPtr arrayVectorFromPyList(const py::list& data) {
 }
 
 velox::ArrayVectorPtr arrayVectorFromPyListByType(
+    int fixed_size,
     velox::TypePtr elementType,
     const py::list& data) {
   switch (elementType->kind()) {
@@ -657,7 +664,7 @@ velox::ArrayVectorPtr arrayVectorFromPyListByType(
     }
     default: {
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          arrayVectorFromPyList, elementType->kind(), data);
+          arrayVectorFromPyList, elementType->kind(), fixed_size, data);
       break;
     }
   }
@@ -681,17 +688,35 @@ void declareArrayType(py::module& m) {
       .def(py::init<velox::TypePtr>())
       .def("element_type", &velox::ArrayType::elementType);
 
+  using J = typename velox::FixedSizeArrayType;
+  py::class_<J, velox::Type, std::shared_ptr<J>>(
+      m, "VeloxFixedArrayType", py::module_local())
+      .def(py::init<int, velox::TypePtr>())
+      .def("element_type", &velox::FixedSizeArrayType::elementType)
+      .def("fixed_width", &velox::FixedSizeArrayType::fixedElementsWidth);
+
   // Empty Column
   m.def("Column", [](std::shared_ptr<I> type) {
     return std::make_unique<ArrayColumn>(type);
   });
+  m.def("Column", [](std::shared_ptr<J> type) {
+    return std::make_unique<ArrayColumn>(type);
+  });
+
   // Column construction from Python list
   m.def(
       "Column",
       [](std::shared_ptr<I> type,
          py::list data) -> std::unique_ptr<ArrayColumn> {
         return std::make_unique<ArrayColumn>(
-            arrayVectorFromPyListByType(type->elementType(), data));
+            arrayVectorFromPyListByType(-1, type->elementType(), data));
+      });
+  m.def(
+      "Column",
+      [](std::shared_ptr<J> type,
+         py::list data) -> std::unique_ptr<ArrayColumn> {
+        return std::make_unique<ArrayColumn>(arrayVectorFromPyListByType(
+            type->fixedElementsWidth(), type->elementType(), data));
       });
 }
 

--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -248,8 +248,8 @@ class List(DType):
     def py_type(self):
         return ty.List[self.item_dtype.py_type]
 
-    def constructor(self, nullable):
-        return List(self.item_dtype, nullable)
+    def constructor(self, nullable, fixed_size=-1):
+        return List(self.item_dtype, nullable, fixed_size)
 
     def __str__(self):
         nullable = ", nullable=" + str(self.nullable) if self.nullable else ""

--- a/torcharrow/test/test_list_column_cpu.py
+++ b/torcharrow/test/test_list_column_cpu.py
@@ -43,6 +43,9 @@ class TestListColumnCpu(TestListColumn):
     def test_map_reduce_etc(self):
         self.base_test_map_reduce_etc()
 
+    def test_fixed_size_list(self):
+        self.base_test_fixed_size_list()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torcharrow/velox_rt/list_column_cpu.py
+++ b/torcharrow/velox_rt/list_column_cpu.py
@@ -35,6 +35,10 @@ class ListColumnCpu(ColumnCpuMixin, ListColumn):
 
         self._data = velox.Column(
             velox.VeloxArrayType(get_velox_type(dtype.item_dtype))
+            if dtype.fixed_size == -1
+            else velox.VeloxFixedArrayType(
+                dtype.fixed_size, get_velox_type(dtype.item_dtype)
+            )
         )
         if len(data) > 0:
             self.append(data)
@@ -91,6 +95,10 @@ class ListColumnCpu(ColumnCpuMixin, ListColumn):
         else:
             new_element_column = ta.column(self._dtype.item_dtype)
             new_element_column = new_element_column.append(value)
+            if self._dtype.fixed_size != -1 and self.dtype.fixed_size != len(
+                new_element_column
+            ):
+                raise ValueError("value incompatible with list fixed_size")
             self._data.append(new_element_column._data)
 
     def _finalize(self):


### PR DESCRIPTION
Summary:
First step to tensor support in TorchArrow API. This change wires up
Velox support for FixedSizeArray Vectors. These fixed sized arrays can
be created using the `fixed_size` parameter of `dtypes.List`, e.g.:

```
ta.column([[1,2], [3,4]], dtype=dt.List(item_dtype=dt.int64, fixed_size=2))
```

Differential Revision: D36232203

