### PR TITLE
Enable building TorchArrow with PyTorch in Facebook CI

### DIFF
--- a/torcharrow/test/lib_test/test_column.py
+++ b/torcharrow/test/lib_test/test_column.py
@@ -12,7 +12,12 @@ from dataclasses import dataclass
 from typing import Any, List, Union
 
 import pyarrow as pa  # @manual=@/third-party:apache-arrow:apache-arrow-py
-import torcharrow._torcharrow as ta
+
+# when _torcharrow is built with torch, we need to import torcharrow._torcharrow after
+# importing torch to avoid running into the following error:
+# https://github.com/pytorch/extension-cpp/issues/6#issuecomment-640191103
+import torcharrow.test.test_utils  # noqa
+import torcharrow._torcharrow as ta  # isort:skip
 from pyarrow.cffi import ffi  # @manual=@/third-party:python-cffi:python-cffi-py
 
 

--- a/torcharrow/test/lib_test/test_udf.py
+++ b/torcharrow/test/lib_test/test_udf.py
@@ -8,7 +8,10 @@
 import unittest
 from typing import Any, List
 
-import torcharrow._torcharrow as ta
+# we need to import torcharrow._torcharrow after importing torch to avoid running into
+# the following error: https://github.com/pytorch/extension-cpp/issues/6#issuecomment-640191103
+import torcharrow.test.test_utils  # noqa
+import torcharrow._torcharrow as ta  # isort:skip
 
 
 class TestSimpleColumns(unittest.TestCase):

--- a/torcharrow/test/test_utils.py
+++ b/torcharrow/test/test_utils.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+try:
+    import torch  # noqa
+
+    pytorch_available = True
+except ModuleNotFoundError:
+    pytorch_available = False

--- a/torcharrow/test/transformation/test_text_ops.py
+++ b/torcharrow/test/transformation/test_text_ops.py
@@ -12,8 +12,9 @@ from pathlib import Path
 import torcharrow as ta
 import torcharrow._torcharrow as _ta
 import torcharrow.dtypes as dt
-import torcharrow.pytorch as tap
+
 from torcharrow import functional
+from torcharrow.test.test_utils import pytorch_available
 
 
 _ASSET_DIR = (Path(__file__).parent.parent / "asset").resolve()
@@ -80,7 +81,7 @@ def init_bpe_encoder():
 class _TestTextOpsBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        if not (tap.available and _ta.is_built_with_torch()):
+        if not (pytorch_available and _ta.is_built_with_torch()):
             raise unittest.SkipTest("Requires PyTorch")
 
         cls.tokenizer = init_bpe_encoder()
@@ -124,14 +125,14 @@ class _TestTextOpsBase(unittest.TestCase):
         raise unittest.SkipTest("abstract base test")
 
     @unittest.skipUnless(
-        tap.available and _ta.is_built_with_torch(), "Requires PyTorch"
+        pytorch_available and _ta.is_built_with_torch(), "Requires PyTorch"
     )
     def test_bpe_encode(self):
         out_df = functional.bpe_tokenize(self.tokenizer, self.df_bpe["text"])
         self.assertEqual(list(out_df), list(self.df_bpe["tokens"]))
 
     @unittest.skipUnless(
-        tap.available and _ta.is_built_with_torch(), "Requires PyTorch"
+        pytorch_available and _ta.is_built_with_torch(), "Requires PyTorch"
     )
     def test_vocab_lookup_indices(self):
         tokens = ["<unk>", "Hello", "world", "How", "are", "you!"]


### PR DESCRIPTION
- This PR enables building TorchArrow with PyTorch in CI. This also allows us to test the functionality of some of the torchtext operators that were added in https://github.com/facebookresearch/torcharrow/pull/271 and https://github.com/facebookresearch/torcharrow/pull/287