### PR TITLE
Fix conda install crash

### DIFF
--- a/packaging/torcharrow/meta.yaml
+++ b/packaging/torcharrow/meta.yaml
@@ -12,7 +12,6 @@ requirements:
   host:
     - python
     - setuptools
-    # {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
     - pytorch
   run:
     - python
@@ -26,7 +25,6 @@ requirements:
     - cffi
     - glog==0.4.0
     - libsodium
-    # {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
     - pytorch
 
 build:

--- a/packaging/torcharrow/meta.yaml
+++ b/packaging/torcharrow/meta.yaml
@@ -12,7 +12,6 @@ requirements:
   host:
     - python
     - setuptools
-    - pytorch
   run:
     - python
     - numpy
@@ -25,7 +24,8 @@ requirements:
     - cffi
     - glog==0.4.0
     - libsodium
-    - pytorch
+    # - pytorch
+    {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
 
 build:
   string: py{{py}}

--- a/packaging/torcharrow/meta.yaml
+++ b/packaging/torcharrow/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - cffi
     - glog==0.4.0
     - libsodium
-    # - pytorch
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
 
 build:

--- a/packaging/torcharrow/meta.yaml
+++ b/packaging/torcharrow/meta.yaml
@@ -12,7 +12,7 @@ requirements:
   host:
     - python
     - setuptools
-    {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
+    # {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
   run:
     - python
     - numpy
@@ -25,7 +25,7 @@ requirements:
     - cffi
     - glog==0.4.0
     - libsodium
-    {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
+    # {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
 
 build:
   string: py{{py}}

--- a/packaging/torcharrow/meta.yaml
+++ b/packaging/torcharrow/meta.yaml
@@ -13,6 +13,7 @@ requirements:
     - python
     - setuptools
     # {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
+    - pytorch
   run:
     - python
     - numpy
@@ -26,6 +27,7 @@ requirements:
     - glog==0.4.0
     - libsodium
     # {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
+    - pytorch
 
 build:
   string: py{{py}}


### PR DESCRIPTION
~~In this PR I removed the version constraint on pytorch. With it, we'll run into some version mismatches when doing `conda install`. Since we don't strongly depend on the nightly build of pytorch itself, this should be a safe change.~~

Actually after discussing with @ejguan, I realized I can simply remove the pytorch nightly dep in the `host` section, and only leave it in the `run` section, as we don't really need pytorch when building. I had it tested and it worked well.