### PR TITLE
Better function-not-found error messages (#1685)

### DIFF
--- a/csrc/velox/functions/rec/tests/BucketizeTest.cpp
+++ b/csrc/velox/functions/rec/tests/BucketizeTest.cpp
@@ -18,6 +18,7 @@
 
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {
 namespace {
@@ -28,6 +29,7 @@ class BucketizeTest : public functions::test::FunctionBaseTest {
  protected:
   static void SetUpTestCase() {
     torcharrow::functions::registerTorchArrowFunctions();
+    parse::registerTypeResolver();
   }
 
   template <typename T, typename T1 = T, typename TExpected = T>

--- a/csrc/velox/functions/rec/tests/ComputeScoreTest.cpp
+++ b/csrc/velox/functions/rec/tests/ComputeScoreTest.cpp
@@ -18,6 +18,7 @@
 
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {
 namespace {
@@ -42,6 +43,7 @@ class ComputeScoreTest : public functions::test::FunctionBaseTest {
   std::vector<std::vector<float>> matchingIdScoresVec;
   static void SetUpTestCase() {
     torcharrow::functions::registerTorchArrowFunctions();
+    parse::registerTypeResolver();
   }
 
   virtual void SetUp() override {

--- a/csrc/velox/functions/rec/tests/FirstXTest.cpp
+++ b/csrc/velox/functions/rec/tests/FirstXTest.cpp
@@ -18,6 +18,7 @@
 
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {
 namespace {
@@ -28,6 +29,7 @@ class firstXTest : public functions::test::FunctionBaseTest {
  protected:
   static void SetUpTestCase() {
     torcharrow::functions::registerTorchArrowFunctions();
+    parse::registerTypeResolver();
   }
 };
 

--- a/csrc/velox/functions/rec/tests/SigridHashTest.cpp
+++ b/csrc/velox/functions/rec/tests/SigridHashTest.cpp
@@ -18,6 +18,7 @@
 
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {
 namespace {
@@ -28,6 +29,7 @@ class SigridHashTest : public functions::test::FunctionBaseTest {
  protected:
   static void SetUpTestCase() {
     torcharrow::functions::registerTorchArrowFunctions();
+    parse::registerTypeResolver();
   }
 
   template <typename T, typename T1 = T, typename TExpected = T>

--- a/csrc/velox/functions/tests/FunctionsTest.cpp
+++ b/csrc/velox/functions/tests/FunctionsTest.cpp
@@ -16,6 +16,7 @@
 #include <velox/vector/SimpleVector.h>
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {
 namespace {
@@ -33,6 +34,7 @@ class FunctionsTest : public functions::test::FunctionBaseTest {
  protected:
   static void SetUpTestCase() {
     torcharrow::functions::registerTorchArrowFunctions();
+    parse::registerTypeResolver();
   }
 
   template <typename T>
@@ -242,7 +244,7 @@ TEST_F(FunctionsTest, bitwise_and) {
       "torcharrow_bitwiseand(c0, c1)",
       {1.2},
       {-3.4},
-      "Cannot resolve function call: torcharrow_bitwiseand(REAL, REAL)");
+      "Scalar function signature is not supported: torcharrow_bitwiseand(REAL, REAL).");
 }
 
 TEST_F(FunctionsTest, bitwise_or) {
@@ -279,7 +281,7 @@ TEST_F(FunctionsTest, bitwise_or) {
       "torcharrow_bitwiseor(c0, c1)",
       {1.2},
       {-3.4},
-      "Cannot resolve function call: torcharrow_bitwiseor(REAL, REAL)");
+      "Scalar function signature is not supported: torcharrow_bitwiseor(REAL, REAL).");
 }
 
 TEST_F(FunctionsTest, round) {


### PR DESCRIPTION
Summary:
Improve error messages when (1) scalar or aggregate function doesn't exit or
doesn't support specified input types; (2) SQL expression has syntax errors.

Before:

- Cannot resolve function call: sum(BIGINT)
- Cannot resolve function call: from_unixtime(BIGINT)
- Parser Error: syntax error at or near "b"

After:

- Aggregate function doesn't exist: sum. Registry of aggregate functions is empty. Make sure to register some aggregate functions.
- Scalar function signature is not supported: to_unixtime(BIGINT). Supported signatures: (row(bigint,smallint)) -> double, (timestamp) -> double.
- Cannot parse expression: func(a b). Parser Error: syntax error at or near "b"

X-link: https://github.com/facebookincubator/velox/pull/1685

Reviewed By: kagamiori

Differential Revision: D36630439

Pulled By: mbasmanova

