### PR TITLE
Update bpe_tokenize UDF to return str instead of int

### DIFF
--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -248,7 +248,7 @@ inline void registerTorchArrowFunctions() {
 
   velox::registerFunction<
       bpe_tokenize,
-      velox::ArrayWriterT<int64_t>,
+      velox::ArrayWriterT<velox::Varchar>,
       std::shared_ptr<GPT2BPEEncoder>,
       velox::Varchar>({"bpe_tokenize"});
 #endif

--- a/csrc/velox/functions/text/bpe_tokenize.h
+++ b/csrc/velox/functions/text/bpe_tokenize.h
@@ -19,10 +19,19 @@ struct bpe_tokenize {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(
-      velox::exec::ArrayWriter<int64_t>& result,
+      velox::exec::ArrayWriter<velox::Varchar>& result,
       const arg_type<std::shared_ptr<GPT2BPEEncoder>>& bpe_encoder,
       const arg_type<velox::Varchar>& text) {
-    result.copy_from(bpe_encoder->Encode(text.str()));
+    std::vector<int64_t> int_result = bpe_encoder->Encode(text.str());
+    std::vector<std::string> str_result;
+    str_result.reserve(int_result.size());
+    std::transform(std::begin(int_result),
+               std::end(int_result), 
+               std::back_inserter(str_result),
+               [](int64_t val) { return std::to_string(val); } 
+              );
+
+    result.copy_from(str_result);
     return true;
   }
 };

--- a/csrc/velox/functions/text/bpe_tokenize.h
+++ b/csrc/velox/functions/text/bpe_tokenize.h
@@ -22,16 +22,7 @@ struct bpe_tokenize {
       velox::exec::ArrayWriter<velox::Varchar>& result,
       const arg_type<std::shared_ptr<GPT2BPEEncoder>>& bpe_encoder,
       const arg_type<velox::Varchar>& text) {
-    std::vector<int64_t> int_result = bpe_encoder->Encode(text.str());
-    std::vector<std::string> str_result;
-    str_result.reserve(int_result.size());
-    std::transform(std::begin(int_result),
-               std::end(int_result), 
-               std::back_inserter(str_result),
-               [](int64_t val) { return std::to_string(val); } 
-              );
-
-    result.copy_from(str_result);
+    result.copy_from(bpe_encoder->Encode(text.str()));
     return true;
   }
 };

--- a/csrc/velox/functions/text/gpt2_bpe_tokenizer.cpp
+++ b/csrc/velox/functions/text/gpt2_bpe_tokenizer.cpp
@@ -281,12 +281,12 @@ std::vector<std::string> GPT2BPEEncoder::PreTokenize_(std::string input) {
   return gpt2_bpe_pre_tokenizer(input);
 }
 
-std::vector<int64_t> GPT2BPEEncoder::Encode(const std::string& text) {
-  std::vector<int64_t> bpe_token_ids;
+std::vector<std::string> GPT2BPEEncoder::Encode(const std::string& text) {
+  std::vector<std::string> bpe_token_ids;
   for (const auto& token : PreTokenize_(text)) {
     auto byte_encoded_token = ByteEncode_(token);
     for (const auto& bpe_token : BPE_(byte_encoded_token)) {
-      bpe_token_ids.push_back(bpe_encoder_.at(bpe_token));
+      bpe_token_ids.push_back(std::to_string(bpe_encoder_.at(bpe_token)));
     }
   }
   return bpe_token_ids;

--- a/csrc/velox/functions/text/gpt2_bpe_tokenizer.h
+++ b/csrc/velox/functions/text/gpt2_bpe_tokenizer.h
@@ -110,7 +110,7 @@ struct GPT2BPEEncoder : torch::CustomClassHolder {
   //  --> bpe encode --> bpe token ids: [707, 5927], [11], [707, 68]
   //  --> result --> [707, 5927, 11, 707, 68]
   //
-  std::vector<int64_t> Encode(const std::string& text);
+  std::vector<std::string> Encode(const std::string& text);
 
   std::unordered_map<std::string, int64_t> GetBPEEncoder() const;
   std::unordered_map<std::string, int64_t> GetBPEMergeRanks() const;

--- a/torcharrow/test/transformation/test_text_ops.py
+++ b/torcharrow/test/transformation/test_text_ops.py
@@ -89,15 +89,15 @@ class _TestTextOpsBase(unittest.TestCase):
                 "text": ["Hello World!, how are you?", "Respublica superiorem"],
                 "labels": [0, 1],
                 "tokens": [
-                    [15496, 2159, 28265, 703, 389, 345, 30],
-                    [4965, 11377, 64, 2208, 72, 29625],
+                    ["15496", "2159", "28265", "703", "389", "345", "30"],
+                    ["4965", "11377", "64", "2208", "72", "29625"],
                 ],
             },
             dtype=dt.Struct(
                 fields=[
                     dt.Field("text", dt.string),
                     dt.Field("labels", dt.int32),
-                    dt.Field("tokens", dt.List(dt.int64)),
+                    dt.Field("tokens", dt.List(dt.string)),
                 ]
             ),
         )


### PR DESCRIPTION
## Description
- Updated `bpe_tokenize` UDF to return string instead of int

## Test
`pytest torcharrow/test/transformation/test_text_ops.py`