### PR TITLE
Add xor implementation to Koski runtime in TorchArrow

### DIFF
--- a/csrc/velox/functions/functions.h
+++ b/csrc/velox/functions/functions.h
@@ -122,6 +122,17 @@ inline void registerTorchArrowFunctions() {
   velox::registerFunction<torcharrow_bitwiseor, int64_t, int64_t, int64_t>(
       {"torcharrow_bitwiseor"});
 
+  velox::registerFunction<torcharrow_bitwisexor, bool, bool, bool>(
+      {"torcharrow_bitwisexor"});
+  velox::registerFunction<torcharrow_bitwisexor, int8_t, int8_t, int8_t>(
+      {"torcharrow_bitwisexor"});
+  velox::registerFunction<torcharrow_bitwisexor, int16_t, int16_t, int16_t>(
+      {"torcharrow_bitwisexor"});
+  velox::registerFunction<torcharrow_bitwisexor, int32_t, int32_t, int32_t>(
+      {"torcharrow_bitwisexor"});
+  velox::registerFunction<torcharrow_bitwisexor, int64_t, int64_t, int64_t>(
+      {"torcharrow_bitwisexor"});
+
   // Round
   velox::registerFunction<torcharrow_round, float, float>({"torcharrow_round"});
   velox::registerFunction<torcharrow_round, double, double>(

--- a/csrc/velox/functions/numeric_functions.h
+++ b/csrc/velox/functions/numeric_functions.h
@@ -178,6 +178,16 @@ struct torcharrow_bitwiseor {
 };
 
 template <typename T>
+struct torcharrow_bitwisexor {
+  template <typename TOutput, typename TInput = TOutput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TOutput& result, const TInput& a, const TInput& b) {
+    result = a ^ b;
+    return true;
+  }
+};
+
+template <typename T>
 struct sigmoid {
   template <typename TOutput, typename TInput = TOutput>
   FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& x) {


### PR DESCRIPTION
Summary:
1. Register bitwise xor function in Koski binding.
2. Register bitwise xor function in Velox functions.
3. Add bitwise xor struct in Velox numeric functions.
4. Add vectorized bitwise xor and reversed xor in Koski numerical columns python file.
5. Add test suite for bitwise xor in python test file for binary operators in Koski runtime.

Reviewed By: OswinC

Differential Revision: D36865019

