### PR TITLE
fix help(torcharrow.functional)

### DIFF
--- a/torcharrow/functional.py
+++ b/torcharrow/functional.py
@@ -100,6 +100,11 @@ def register_factory_methods(methods):
 
 
 def __getattr__(op_name: str):
+    # Don't wrap accesses for special module members, like __bases__
+    # as it breaks basic Python functionality like
+    # `help(torcharrow.functional)`
+    if op_name.startswith("__") or op_name == "_fields":
+        raise AttributeError
     wrapper = create_dispatch_wrapper(op_name)
     setattr(sys.modules["torcharrow.functional"], op_name, wrapper)
     return wrapper


### PR DESCRIPTION
Summary:
Too much Python black magic broke `help(torcharrow.functional)`:

```
>> import torcharrow
>> help(torcharrow.functional)
<several stack frames elided>
/usr/local/fbcode/platform010/lib/python3.8/inspect.py in getmembers(object, predicate)
    337     # attribute with the same name as a DynamicClassAttribute exists
    338     try:
--> 339         for base in object.__bases__:
    340             for k, v in base.__dict__.items():
    341                 if isinstance(v, types.DynamicClassAttribute):

TypeError: 'functools.partial' object is not iterable
```
We need to not auto-generate wrapped functions for requests for python
internal module members as this causes default functionality to break
in confusing ways.

Reviewed By: bearzx

Differential Revision: D36913734

