### PR TITLE
Introduce wheel build workflow for release

### DIFF
--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -63,7 +63,8 @@ jobs:
           pip3 install dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
-          pytest -v torcharrow/test/integration
+          # pytest -v torcharrow/test/integration
+          python torcharrow/test/integration/test_criteo.py
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -52,6 +52,13 @@ jobs:
           name: torcharrow-artifact
           path: dist/torcharrow*.whl
 
+      - name: Install and Test TorchArrow Wheel
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          pip3 install dist/torcharrow*.whl
+
   macos-container:
     runs-on: macos-latest
     strategy:
@@ -86,3 +93,10 @@ jobs:
         with:
           name: torcharrow-artifact
           path: dist/torcharrow*.whl
+
+      - name: Install and Test TorchArrow Wheel
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          pip3 install dist/torcharrow*.whl

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -3,6 +3,13 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Use the following to trigger test on a dev PR
+  pull_request:
+   branches:
+     - main
+     # For PR created by ghstack
+     - gh/*/*/base
+
   workflow_call:
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID:

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -10,13 +10,6 @@ on:
      # For PR created by ghstack
      - gh/*/*/base
 
-  workflow_call:
-    secrets:
-      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID:
-        required: true
-      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY:
-        required: true
-
 jobs:
   linux-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -3,13 +3,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Use the following to trigger test on a dev PR
-  pull_request:
-   branches:
-     - main
-     # For PR created by ghstack
-     - gh/*/*/base
-
   workflow_call:
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID:
@@ -35,7 +28,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v2
         with:
-            ref: release/0.1.0
+            ref: "release/0.1.0"
             submodules: recursive
 
       - name: Build the wheel
@@ -70,7 +63,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v2
         with:
-            ref: release/0.1.0
+            ref: "release/0.1.0"
             submodules: recursive
 
       - name: Build the wheel

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v2
         with:
-            # ref: "release/0.1.0"
+            ref: "release/0.1.0"
             submodules: recursive
 
       - name: Build the wheel
@@ -67,7 +67,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v2
         with:
-            # ref: "release/0.1.0"
+            ref: "release/0.1.0"
             submodules: recursive
 
       - name: Build the wheel

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -18,9 +18,53 @@ on:
         required: true
 
 jobs:
+  # linux-container:
+  #   runs-on: ubuntu-latest
+  #   container: prestocpp/velox-sse-velox-torcharrow:kpai-20220524
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version:
+  #         - 3.7
+  #         - 3.8
+  #         - 3.9
+  #   steps:
+  #     - name: Print CPU info
+  #       run: cat /proc/cpuinfo
+
+  #     - name: Check out source repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #           # ref: "release/0.1.0"
+  #           submodules: recursive
+
+  #     - name: Build the wheel
+  #       run: |
+  #         source /opt/conda/etc/profile.d/conda.sh
+  #         BUILD_VERSION=0.1.0 PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
+  #         conda activate env${{ matrix.python-version }}
+  #         pip install auditwheel
+  #         auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
+
+  #     - name: Install and Test TorchArrow Wheel
+  #       shell: bash
+  #       env:
+  #         PYTHON_VERSION: ${{ matrix.python-version }}
+  #       run: |
+  #         source packaging/manylinux/python_helper.sh
+  #         pip3 install dist/torcharrow*.whl
+  #         pip3 install pytest
+  #         pip3 install torch
+  #         pytest torcharrow/test/integration
+
+  #     - name: Upload Wheels to Github
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: torcharrow-artifact
+  #         path: dist/torcharrow*.whl
+
   linux-container:
     runs-on: ubuntu-latest
-    container: prestocpp/velox-sse-velox-torcharrow:kpai-20220524
     strategy:
       fail-fast: false
       matrix:
@@ -28,9 +72,15 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+
     steps:
       - name: Print CPU info
         run: cat /proc/cpuinfo
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Check out source repository
         uses: actions/checkout@v2
@@ -38,11 +88,43 @@ jobs:
             # ref: "release/0.1.0"
             submodules: recursive
 
+      # Based on https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        run: |
+          echo "::set-output name=timestamp::$(/bin/date -u "+%Y%m%d-%H:%M:%S")"
+        shell: bash
+
+      - name: Load ccache files
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: ubuntu-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+              ubuntu-ccache-
+
+      - name: Install dependencies with APT
+        run: |
+          sudo apt-get update
+          sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
+          libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
+          libgflags-dev libevent-dev libre2-dev
+
+      # Based on https://github.com/facebookincubator/velox/blob/99429407c3d524e07b32b8b19a03aa7382f819cf/.circleci/config.yml#L114-L116
+      - name: Configure ccache
+        run: |
+          echo "$GITHUB_WORKSPACE"
+          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root ccache -sz -M 1G
+          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz -M 1G
+
+      - name: Build and install folly and fmt
+        # sudo doesn't preserve environment vairable; set it after sudo: https://stackoverflow.com/questions/8633461/how-to-keep-environment-variables-when-using-sudo/33183620#33183620
+        run: |
+          sudo CMAKE_C_COMPILER_LAUNCHER=ccache CPU_TARGET="sse" CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root scripts/setup-ubuntu.sh
+
       - name: Build the wheel
         run: |
-          source /opt/conda/etc/profile.d/conda.sh
           BUILD_VERSION=0.1.0 PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
-          conda activate env${{ matrix.python-version }}
           pip install auditwheel
           auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
 
@@ -63,47 +145,47 @@ jobs:
           name: torcharrow-artifact
           path: dist/torcharrow*.whl
 
-  macos-container:
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - 3.7
-          - 3.8
-          - 3.9
-    steps:
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+  # macos-container:
+  #   runs-on: macos-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version:
+  #         - 3.7
+  #         - 3.8
+  #         - 3.9
+  #   steps:
+  #     - name: Setup Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
 
-      - name: Check out source repository
-        uses: actions/checkout@v2
-        with:
-            # ref: "release/0.1.0"
-            submodules: recursive
+  #     - name: Check out source repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #           # ref: "release/0.1.0"
+  #           submodules: recursive
 
-      - name: Build the wheel
-        run: |
-          MACOSX_DEPLOYMENT_TARGET=10.15 CPU_TARGET="sse" ./csrc/velox/velox/scripts/setup-macos.sh
-          pip install wheel
-          CPU_TARGET="sse" ./packaging/build_wheel.sh
-          pip install delocate
-          delocate-wheel dist/*.whl -w fixed_dist
+  #     - name: Build the wheel
+  #       run: |
+  #         MACOSX_DEPLOYMENT_TARGET=10.15 CPU_TARGET="sse" ./csrc/velox/velox/scripts/setup-macos.sh
+  #         pip install wheel
+  #         CPU_TARGET="sse" ./packaging/build_wheel.sh
+  #         pip install delocate
+  #         delocate-wheel dist/*.whl -w fixed_dist
 
-      - name: Install and Test TorchArrow Wheel
-        shell: bash
-        env:
-          PYTHON_VERSION: ${{ matrix.python-version }}
-        run: |
-          pip3 install dist/torcharrow*.whl
-          pip3 install pytest
-          pip3 install torch
-          pytest torcharrow/test/integration
+  #     - name: Install and Test TorchArrow Wheel
+  #       shell: bash
+  #       env:
+  #         PYTHON_VERSION: ${{ matrix.python-version }}
+  #       run: |
+  #         pip3 install dist/torcharrow*.whl
+  #         pip3 install pytest
+  #         pip3 install torch
+  #         pytest torcharrow/test/integration
 
-      - name: Upload Wheels to Github
-        uses: actions/upload-artifact@v2
-        with:
-          name: torcharrow-artifact
-          path: dist/torcharrow*.whl
+  #     - name: Upload Wheels to Github
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: torcharrow-artifact
+  #         path: dist/torcharrow*.whl

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -38,13 +38,13 @@ jobs:
             # ref: "release/0.1.0"
             submodules: recursive
 
-      - name: Install dependencies with APT
-        run: |
-          sudo apt-get update
-          # sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
-          # libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
-          # libgflags-dev libevent-dev libre2-dev
-          sudo apt install -y libboost-all-dev
+      # - name: Install dependencies with APT
+      #   run: |
+      #     sudo apt-get update
+      #     # sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
+      #     # libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
+      #     # libgflags-dev libevent-dev libre2-dev
+      #     sudo apt install -y libboost-all-dev
 
       - name: Build the wheel
         run: |
@@ -63,7 +63,7 @@ jobs:
           pip3 install dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
-          pytest torcharrow/test/integration
+          pytest -v torcharrow/test/integration
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -54,17 +54,17 @@ jobs:
           pip install auditwheel
           auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
 
-      - name: Install and Test TorchArrow Wheel
-        shell: bash
-        env:
-          PYTHON_VERSION: ${{ matrix.python-version }}
-        run: |
-          source packaging/manylinux/python_helper.sh
-          pip3 install dist/torcharrow*.whl
-          pip3 install pytest
-          pip3 install torch
-          # pytest -v torcharrow/test/integration
-          python torcharrow/test/integration/test_criteo.py
+      # - name: Install and Test TorchArrow Wheel
+      #   shell: bash
+      #   env:
+      #     PYTHON_VERSION: ${{ matrix.python-version }}
+      #   run: |
+      #     source packaging/manylinux/python_helper.sh
+      #     pip3 install dist/torcharrow*.whl
+      #     pip3 install pytest
+      #     pip3 install torch
+      #     # pytest -v torcharrow/test/integration
+      #     python torcharrow/test/integration/test_criteo.py
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -64,7 +64,7 @@ jobs:
           pip3 install fixed_dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
-          pytest -v torcharrow/test/integration
+          pytest -v torcharrow/test
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2
@@ -154,47 +154,47 @@ jobs:
   #         name: torcharrow-artifact
   #         path: dist/torcharrow*.whl
 
-  # macos-container:
-  #   runs-on: macos-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version:
-  #         - 3.7
-  #         - 3.8
-  #         - 3.9
-  #   steps:
-  #     - name: Setup Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
+  macos-container:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - 3.7
+          - 3.8
+          - 3.9
+    steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-  #     - name: Check out source repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #           # ref: "release/0.1.0"
-  #           submodules: recursive
+      - name: Check out source repository
+        uses: actions/checkout@v2
+        with:
+            # ref: "release/0.1.0"
+            submodules: recursive
 
-  #     - name: Build the wheel
-  #       run: |
-  #         MACOSX_DEPLOYMENT_TARGET=10.15 CPU_TARGET="sse" ./csrc/velox/velox/scripts/setup-macos.sh
-  #         pip install wheel
-  #         CPU_TARGET="sse" ./packaging/build_wheel.sh
-  #         pip install delocate
-  #         delocate-wheel dist/*.whl -w fixed_dist
+      - name: Build the wheel
+        run: |
+          MACOSX_DEPLOYMENT_TARGET=10.15 CPU_TARGET="sse" ./csrc/velox/velox/scripts/setup-macos.sh
+          pip install wheel
+          CPU_TARGET="sse" ./packaging/build_wheel.sh
+          pip install delocate
+          delocate-wheel dist/*.whl -w fixed_dist
 
-  #     - name: Install and Test TorchArrow Wheel
-  #       shell: bash
-  #       env:
-  #         PYTHON_VERSION: ${{ matrix.python-version }}
-  #       run: |
-  #         pip3 install dist/torcharrow*.whl
-  #         pip3 install pytest
-  #         pip3 install torch
-  #         pytest torcharrow/test/integration
+      - name: Install and Test TorchArrow Wheel
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          pip3 install dist/torcharrow*.whl
+          pip3 install pytest
+          pip3 install torch
+          pytest torcharrow/test
 
-  #     - name: Upload Wheels to Github
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: torcharrow-artifact
-  #         path: dist/torcharrow*.whl
+      - name: Upload Wheels to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: torcharrow-artifact
+          path: dist/torcharrow*.whl

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -1,0 +1,80 @@
+name: TorchArrow RC Build and Test
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID:
+        required: true
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY:
+        required: true
+
+jobs:
+  linux-container:
+    runs-on: ubuntu-latest
+    container: prestocpp/velox-sse-velox-torcharrow:kpai-20220524
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - 3.7
+          - 3.8
+          - 3.9
+    steps:
+      - name: Print CPU info
+        run: cat /proc/cpuinfo
+
+      - name: Check out source repository
+        uses: actions/checkout@v2
+        with:
+            ref: release/0.1.0
+            submodules: recursive
+
+      - name: Build the wheel
+        run: |
+          source /opt/conda/etc/profile.d/conda.sh
+          BUILD_VERSION=0.1.0 PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
+          conda activate env${{ matrix.python-version }}
+          pip install auditwheel
+          auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
+
+      - name: Upload Wheels to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: torcharrow-artifact
+          path: dist/torcharrow*.whl
+
+  macos-container:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - 3.7
+          - 3.8
+          - 3.9
+    steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Check out source repository
+        uses: actions/checkout@v2
+        with:
+            ref: release/0.1.0
+            submodules: recursive
+
+      - name: Build the wheel
+        run: |
+          MACOSX_DEPLOYMENT_TARGET=10.15 CPU_TARGET="sse" ./csrc/velox/velox/scripts/setup-macos.sh
+          pip install wheel
+          CPU_TARGET="sse" ./packaging/build_wheel.sh
+          pip install delocate
+          delocate-wheel dist/*.whl -w fixed_dist
+
+      - name: Upload Wheels to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: torcharrow-artifact
+          path: dist/torcharrow*.whl

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
+          source packaging/manylinux/python_helper.sh
           pip3 install dist/torcharrow*.whl
 
   macos-container:

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -55,7 +55,7 @@ jobs:
           pip3 install dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
-          pytest --no-header -v torcharrow/test
+          pytest torcharrow/test/integration
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2
@@ -100,7 +100,7 @@ jobs:
           pip3 install dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
-          pytest --no-header -v torcharrow/test
+          pytest torcharrow/test/integration
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -38,14 +38,6 @@ jobs:
             # ref: "release/0.1.0"
             submodules: recursive
 
-      # - name: Install dependencies with APT
-      #   run: |
-      #     sudo apt-get update
-      #     # sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
-      #     # libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
-      #     # libgflags-dev libevent-dev libre2-dev
-      #     sudo apt install -y libboost-all-dev
-
       - name: Build the wheel
         run: |
           source /opt/conda/etc/profile.d/conda.sh
@@ -60,7 +52,6 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           source packaging/manylinux/python_helper.sh
-          # pip3 install dist/torcharrow*.whl
           pip3 install fixed_dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
@@ -71,88 +62,6 @@ jobs:
         with:
           name: torcharrow-artifact
           path: dist/torcharrow*.whl
-
-  # linux-container:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version:
-  #         - 3.7
-  #         - 3.8
-  #         - 3.9
-
-  #   steps:
-  #     - name: Print CPU info
-  #       run: cat /proc/cpuinfo
-
-  #     - name: Setup Python environment
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-
-  #     - name: Check out source repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #           # ref: "release/0.1.0"
-  #           submodules: recursive
-
-  #     # Based on https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
-  #     - name: Prepare ccache timestamp
-  #       id: ccache_cache_timestamp
-  #       run: |
-  #         echo "::set-output name=timestamp::$(/bin/date -u "+%Y%m%d-%H:%M:%S")"
-  #       shell: bash
-
-  #     - name: Load ccache files
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: .ccache
-  #         key: ubuntu-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-  #         restore-keys: |
-  #             ubuntu-ccache-
-
-  #     - name: Install dependencies with APT
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
-  #         libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
-  #         libgflags-dev libevent-dev libre2-dev
-
-  #     # Based on https://github.com/facebookincubator/velox/blob/99429407c3d524e07b32b8b19a03aa7382f819cf/.circleci/config.yml#L114-L116
-  #     - name: Configure ccache
-  #       run: |
-  #         echo "$GITHUB_WORKSPACE"
-  #         CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root ccache -sz -M 1G
-  #         CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz -M 1G
-
-  #     - name: Build and install folly and fmt
-  #       # sudo doesn't preserve environment vairable; set it after sudo: https://stackoverflow.com/questions/8633461/how-to-keep-environment-variables-when-using-sudo/33183620#33183620
-  #       run: |
-  #         sudo CMAKE_C_COMPILER_LAUNCHER=ccache CPU_TARGET="sse" CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root scripts/setup-ubuntu.sh
-
-  #     - name: Build the wheel
-  #       run: |
-  #         BUILD_VERSION=0.1.0 PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
-  #         pip install auditwheel
-  #         auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
-
-  #     - name: Install and Test TorchArrow Wheel
-  #       shell: bash
-  #       env:
-  #         PYTHON_VERSION: ${{ matrix.python-version }}
-  #       run: |
-  #         source packaging/manylinux/python_helper.sh
-  #         pip3 install dist/torcharrow*.whl
-  #         pip3 install pytest
-  #         pip3 install torch
-  #         pytest torcharrow/test/integration
-
-  #     - name: Upload Wheels to Github
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: torcharrow-artifact
-  #         path: dist/torcharrow*.whl
 
   macos-container:
     runs-on: macos-latest
@@ -188,7 +97,7 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          pip3 install dist/torcharrow*.whl
+          pip3 install fixed_dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
           pytest -v torcharrow/test/integration

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -18,53 +18,9 @@ on:
         required: true
 
 jobs:
-  # linux-container:
-  #   runs-on: ubuntu-latest
-  #   container: prestocpp/velox-sse-velox-torcharrow:kpai-20220524
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version:
-  #         - 3.7
-  #         - 3.8
-  #         - 3.9
-  #   steps:
-  #     - name: Print CPU info
-  #       run: cat /proc/cpuinfo
-
-  #     - name: Check out source repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #           # ref: "release/0.1.0"
-  #           submodules: recursive
-
-  #     - name: Build the wheel
-  #       run: |
-  #         source /opt/conda/etc/profile.d/conda.sh
-  #         BUILD_VERSION=0.1.0 PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
-  #         conda activate env${{ matrix.python-version }}
-  #         pip install auditwheel
-  #         auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
-
-  #     - name: Install and Test TorchArrow Wheel
-  #       shell: bash
-  #       env:
-  #         PYTHON_VERSION: ${{ matrix.python-version }}
-  #       run: |
-  #         source packaging/manylinux/python_helper.sh
-  #         pip3 install dist/torcharrow*.whl
-  #         pip3 install pytest
-  #         pip3 install torch
-  #         pytest torcharrow/test/integration
-
-  #     - name: Upload Wheels to Github
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: torcharrow-artifact
-  #         path: dist/torcharrow*.whl
-
   linux-container:
     runs-on: ubuntu-latest
+    container: prestocpp/velox-sse-velox-torcharrow:kpai-20220524
     strategy:
       fail-fast: false
       matrix:
@@ -72,15 +28,9 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-
     steps:
       - name: Print CPU info
         run: cat /proc/cpuinfo
-
-      - name: Setup Python environment
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Check out source repository
         uses: actions/checkout@v2
@@ -88,43 +38,19 @@ jobs:
             # ref: "release/0.1.0"
             submodules: recursive
 
-      # Based on https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          echo "::set-output name=timestamp::$(/bin/date -u "+%Y%m%d-%H:%M:%S")"
-        shell: bash
-
-      - name: Load ccache files
-        uses: actions/cache@v2
-        with:
-          path: .ccache
-          key: ubuntu-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-              ubuntu-ccache-
-
       - name: Install dependencies with APT
         run: |
           sudo apt-get update
-          sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
-          libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
-          libgflags-dev libevent-dev libre2-dev
-
-      # Based on https://github.com/facebookincubator/velox/blob/99429407c3d524e07b32b8b19a03aa7382f819cf/.circleci/config.yml#L114-L116
-      - name: Configure ccache
-        run: |
-          echo "$GITHUB_WORKSPACE"
-          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root ccache -sz -M 1G
-          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz -M 1G
-
-      - name: Build and install folly and fmt
-        # sudo doesn't preserve environment vairable; set it after sudo: https://stackoverflow.com/questions/8633461/how-to-keep-environment-variables-when-using-sudo/33183620#33183620
-        run: |
-          sudo CMAKE_C_COMPILER_LAUNCHER=ccache CPU_TARGET="sse" CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root scripts/setup-ubuntu.sh
+          # sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
+          # libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
+          # libgflags-dev libevent-dev libre2-dev
+          sudo apt install -y libboost-all-dev
 
       - name: Build the wheel
         run: |
+          source /opt/conda/etc/profile.d/conda.sh
           BUILD_VERSION=0.1.0 PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
+          conda activate env${{ matrix.python-version }}
           pip install auditwheel
           auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
 
@@ -144,6 +70,88 @@ jobs:
         with:
           name: torcharrow-artifact
           path: dist/torcharrow*.whl
+
+  # linux-container:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version:
+  #         - 3.7
+  #         - 3.8
+  #         - 3.9
+
+  #   steps:
+  #     - name: Print CPU info
+  #       run: cat /proc/cpuinfo
+
+  #     - name: Setup Python environment
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+
+  #     - name: Check out source repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #           # ref: "release/0.1.0"
+  #           submodules: recursive
+
+  #     # Based on https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+  #     - name: Prepare ccache timestamp
+  #       id: ccache_cache_timestamp
+  #       run: |
+  #         echo "::set-output name=timestamp::$(/bin/date -u "+%Y%m%d-%H:%M:%S")"
+  #       shell: bash
+
+  #     - name: Load ccache files
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: .ccache
+  #         key: ubuntu-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+  #         restore-keys: |
+  #             ubuntu-ccache-
+
+  #     - name: Install dependencies with APT
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt install -y g++ cmake ccache ninja-build checkinstall git \
+  #         libssl-dev libboost-all-dev libdouble-conversion-dev libgoogle-glog-dev \
+  #         libgflags-dev libevent-dev libre2-dev
+
+  #     # Based on https://github.com/facebookincubator/velox/blob/99429407c3d524e07b32b8b19a03aa7382f819cf/.circleci/config.yml#L114-L116
+  #     - name: Configure ccache
+  #       run: |
+  #         echo "$GITHUB_WORKSPACE"
+  #         CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root ccache -sz -M 1G
+  #         CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -sz -M 1G
+
+  #     - name: Build and install folly and fmt
+  #       # sudo doesn't preserve environment vairable; set it after sudo: https://stackoverflow.com/questions/8633461/how-to-keep-environment-variables-when-using-sudo/33183620#33183620
+  #       run: |
+  #         sudo CMAKE_C_COMPILER_LAUNCHER=ccache CPU_TARGET="sse" CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=$GITHUB_WORKSPACE/.ccache_root scripts/setup-ubuntu.sh
+
+  #     - name: Build the wheel
+  #       run: |
+  #         BUILD_VERSION=0.1.0 PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
+  #         pip install auditwheel
+  #         auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
+
+  #     - name: Install and Test TorchArrow Wheel
+  #       shell: bash
+  #       env:
+  #         PYTHON_VERSION: ${{ matrix.python-version }}
+  #       run: |
+  #         source packaging/manylinux/python_helper.sh
+  #         pip3 install dist/torcharrow*.whl
+  #         pip3 install pytest
+  #         pip3 install torch
+  #         pytest torcharrow/test/integration
+
+  #     - name: Upload Wheels to Github
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: torcharrow-artifact
+  #         path: dist/torcharrow*.whl
 
   # macos-container:
   #   runs-on: macos-latest

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build the wheel
         run: |
           source /opt/conda/etc/profile.d/conda.sh
-          BUILD_VERSION=0.1.0 PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
+          PYTHON_VERSION=${{ matrix.python-version }} CPU_TARGET="sse" packaging/build_wheel.sh
           conda activate env${{ matrix.python-version }}
           pip install auditwheel
           auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -15,9 +15,6 @@ jobs:
           - 3.8
           - 3.9
     steps:
-      - name: Print CPU info
-        run: cat /proc/cpuinfo
-
       - name: Check out source repository
         uses: actions/checkout@v2
         with:
@@ -47,7 +44,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: torcharrow-artifact
-          path: dist/torcharrow*.whl
+          path: fixed_dist/torcharrow*.whl
 
   macos-container:
     runs-on: macos-latest
@@ -92,4 +89,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: torcharrow-artifact
-          path: dist/torcharrow*.whl
+          path: fixed_dist/torcharrow*.whl

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -2,6 +2,14 @@ name: TorchArrow RC Build and Test
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+  # Use the following to trigger test on a dev PR
+  pull_request:
+   branches:
+     - main
+     # For PR created by ghstack
+     - gh/*/*/base
+
   workflow_call:
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID:

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -53,6 +53,9 @@ jobs:
         run: |
           source packaging/manylinux/python_helper.sh
           pip3 install dist/torcharrow*.whl
+          pip3 install pytest
+          pip3 install torch
+          pytest --no-header -v torcharrow/test
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2
@@ -95,6 +98,9 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           pip3 install dist/torcharrow*.whl
+          pip3 install pytest
+          pip3 install torch
+          pytest --no-header -v torcharrow/test
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -54,17 +54,17 @@ jobs:
           pip install auditwheel
           auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
 
-      # - name: Install and Test TorchArrow Wheel
-      #   shell: bash
-      #   env:
-      #     PYTHON_VERSION: ${{ matrix.python-version }}
-      #   run: |
-      #     source packaging/manylinux/python_helper.sh
-      #     pip3 install dist/torcharrow*.whl
-      #     pip3 install pytest
-      #     pip3 install torch
-      #     # pytest -v torcharrow/test/integration
-      #     python torcharrow/test/integration/test_criteo.py
+      - name: Install and Test TorchArrow Wheel
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          source packaging/manylinux/python_helper.sh
+          # pip3 install dist/torcharrow*.whl
+          pip3 install fixed_dist/torcharrow*.whl
+          pip3 install pytest
+          pip3 install torch
+          pytest -v torcharrow/test/integration
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -46,12 +46,6 @@ jobs:
           pip install auditwheel
           auditwheel repair dist/*.whl -w fixed_dist --plat manylinux2014_x86_64
 
-      - name: Upload Wheels to Github
-        uses: actions/upload-artifact@v2
-        with:
-          name: torcharrow-artifact
-          path: dist/torcharrow*.whl
-
       - name: Install and Test TorchArrow Wheel
         shell: bash
         env:
@@ -59,6 +53,12 @@ jobs:
         run: |
           source packaging/manylinux/python_helper.sh
           pip3 install dist/torcharrow*.whl
+
+      - name: Upload Wheels to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: torcharrow-artifact
+          path: dist/torcharrow*.whl
 
   macos-container:
     runs-on: macos-latest
@@ -89,15 +89,15 @@ jobs:
           pip install delocate
           delocate-wheel dist/*.whl -w fixed_dist
 
-      - name: Upload Wheels to Github
-        uses: actions/upload-artifact@v2
-        with:
-          name: torcharrow-artifact
-          path: dist/torcharrow*.whl
-
       - name: Install and Test TorchArrow Wheel
         shell: bash
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           pip3 install dist/torcharrow*.whl
+
+      - name: Upload Wheels to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: torcharrow-artifact
+          path: dist/torcharrow*.whl

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -64,7 +64,8 @@ jobs:
           pip3 install fixed_dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
-          pytest -v torcharrow/test
+          pytest -v torcharrow/test/integration
+          pytest -v torcharrow/test/lib_test
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2
@@ -191,7 +192,8 @@ jobs:
           pip3 install dist/torcharrow*.whl
           pip3 install pytest
           pip3 install torch
-          pytest torcharrow/test
+          pytest -v torcharrow/test/integration
+          pytest -v torcharrow/test/lib_test
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -65,7 +65,6 @@ jobs:
           pip3 install pytest
           pip3 install torch
           pytest -v torcharrow/test/integration
-          pytest -v torcharrow/test/lib_test
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2
@@ -193,7 +192,6 @@ jobs:
           pip3 install pytest
           pip3 install torch
           pytest -v torcharrow/test/integration
-          pytest -v torcharrow/test/lib_test
 
       - name: Upload Wheels to Github
         uses: actions/upload-artifact@v2

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -3,13 +3,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Use the following to trigger test on a dev PR
-  pull_request:
-   branches:
-     - main
-     # For PR created by ghstack
-     - gh/*/*/base
-
 jobs:
   linux-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/rc-wheel-build.yml
+++ b/.github/workflows/rc-wheel-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v2
         with:
-            ref: "release/0.1.0"
+            # ref: "release/0.1.0"
             submodules: recursive
 
       - name: Build the wheel
@@ -78,7 +78,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v2
         with:
-            ref: "release/0.1.0"
+            # ref: "release/0.1.0"
             submodules: recursive
 
       - name: Build the wheel

--- a/packaging/manylinux/python_helper.sh
+++ b/packaging/manylinux/python_helper.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+python_nodot="$(echo $PYTHON_VERSION | tr -d '.')"
+case $PYTHON_VERSION in
+  3.[6-7]*)
+    DESIRED_PYTHON="cp${python_nodot}-cp${python_nodot}m"
+    ;;
+  3.*)
+    DESIRED_PYTHON="cp${python_nodot}-cp${python_nodot}"
+    ;;
+esac
+
+pydir="/opt/python/$DESIRED_PYTHON"
+export PATH="$pydir/bin:$PATH"


### PR DESCRIPTION
In this PR I added another GHA for the beta release. It's mostly copied from `nightly-wheel.yml` so some refactoring or unification work can be forseen in the future. But here I wanted it to start simple and separate.

The workflow will checkout the release branch, build, run the criteo integration test, then upload it to github so it can be retrieved to upload to pypi.

TODO: since `release/0.1.0` is already created, after this PR is merged to `main`, I'll need to merge the `main` branch to `release/0.1.0`.